### PR TITLE
feat(config): add YAML config loader

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -60,3 +60,18 @@ pnpm dev
 ```
 
 Your app template should now be running on [localhost:3000](http://localhost:3000).
+
+## Loading YAML configuration
+
+Use `loadYamlConfig` to read config files stored in the project `config` directory:
+
+```ts
+import { loadYamlConfig } from '@/lib/config-loader';
+
+interface ServerConfig {
+  host: string;
+  port: number;
+}
+
+const config = loadYamlConfig<ServerConfig>('server.yml');
+```

--- a/apps/web/lib/config-loader.ts
+++ b/apps/web/lib/config-loader.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+
+/**
+ * Loads a YAML configuration file from the project `config` directory.
+ *
+ * @example
+ * interface ServerConfig {
+ *   host: string;
+ *   port: number;
+ * }
+ * const cfg = loadYamlConfig<ServerConfig>('server.yml');
+ *
+ * @param filename - Name of the YAML file to load relative to `config/`.
+ * @template T - Expected shape of the parsed configuration object.
+ * @throws If the file cannot be read or contains invalid YAML.
+ * @returns Parsed configuration typed as `T`.
+ */
+export function loadYamlConfig<T>(filename: string): T {
+  const filePath = resolve(process.cwd(), 'config', filename);
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, 'utf8');
+  } catch {
+    throw new Error(`Config file not found: ${filePath}`);
+  }
+
+  try {
+    return parse(content) as T;
+  } catch (err) {
+    throw new Error(`Failed to parse YAML in ${filePath}: ${(err as Error).message}`);
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -86,6 +86,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.0",
+    "yaml": "^2.8.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       usehooks-ts:
         specifier: ^3.1.0
         version: 3.1.1(react@19.0.0-rc-45804af1-20241021)
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.0
       zod:
         specifier: ^3.23.8
         version: 3.25.67


### PR DESCRIPTION
## Summary
- document YAML config loader with detailed JSDoc

## Testing
- `pnpm lint` in `apps/web`
- `pnpm test` *(fails: serving HTML report)*

------
https://chatgpt.com/codex/tasks/task_e_6859e6368cf883288503bcce1e36ad40