### PR TITLE
Add chat title update features

### DIFF
--- a/apps/web/lib/db/queries.ts
+++ b/apps/web/lib/db/queries.ts
@@ -469,6 +469,23 @@ export async function updateChatVisiblityById({
   }
 }
 
+export async function updateChatTitleById({
+  chatId,
+  title,
+}: {
+  chatId: string;
+  title: string;
+}) {
+  try {
+    return await db.update(chat).set({ title }).where(eq(chat.id, chatId));
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to update chat title by id',
+    );
+  }
+}
+
 export async function getMessageCountByUserId({
   id,
   differenceInHours,


### PR DESCRIPTION
## Summary
- add `updateChatTitleById` DB helper
- update chat title when the first assistant message is saved
- add PATCH `/api/chat` endpoint for renaming
- allow renaming chats from sidebar dropdown

## Testing
- `pnpm -r test` *(fails: 34 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_685b30e24b448328a8ff917c9d84674f