### PR TITLE
feat: add keyboard shortcut to create new chat

### DIFF
--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -44,6 +44,26 @@ export function AppSidebar({ user }: { user: User | undefined }) {
 
   const modifierKey = useModifierKey();
 
+  const NEW_CHAT_SHORTCUT_KEY = 'o';
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.shiftKey &&
+        event.key.toLowerCase() === NEW_CHAT_SHORTCUT_KEY
+      ) {
+        event.preventDefault();
+        setOpenMobile(false);
+        router.push('/');
+        router.refresh();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [router, setOpenMobile]);
+
   return (
     <Sidebar className="group-data-[side=left]:border-r-0">
       <SidebarHeader>

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -23,6 +23,8 @@ import { PlusIcon } from './icons';
 import { cn } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 
+const NEW_CHAT_SHORTCUT_KEY = 'o';
+
 function useModifierKey() {
   const [key, setKey] = useState<'Ctrl' | '⌘'>('Ctrl'); // safe default for SSR
 
@@ -43,8 +45,6 @@ export function AppSidebar({ user }: { user: User | undefined }) {
   const pathname = usePathname();
 
   const modifierKey = useModifierKey();
-
-  const NEW_CHAT_SHORTCUT_KEY = 'o';
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -103,7 +103,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                         pathname === '/' ? 'opacity-100' : 'opacity-0 group-hover/button:opacity-100'
                       )}
                     >
-                      {modifierKey}+Shift+O
+                      {modifierKey}+Shift+{NEW_CHAT_SHORTCUT_KEY.toUpperCase()}
                     </kbd>
                   </Link>
                 </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- add global keyboard handler for new chat (Ctrl/Cmd + Shift + O)

## Testing
- `pnpm --filter ./apps/web lint` *(fails: tsconfig parse error)*
- `pnpm -r test` *(fails to run e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_685bbab478d8832894408f364f12b61e