### PR TITLE
feat(api): multi-tenant chat/message schema + ContextBuilder + per-request RLS (#53)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,22 +41,15 @@ Scope to one workspace with `pnpm --filter web <script>` (or `--filter api`).
 
 ## Local database (docker)
 
-`compose.yaml` at the repo root runs Postgres for development. It provisions a
-**non-superuser `app` role that owns the schema**, so Row-Level Security (incl. `FORCE`)
-is exercised in dev exactly as in a self-hosted deployment — a superuser would silently
-bypass the multi-tenant moat.
+`compose.yaml` (repo root) runs Postgres for dev. One-time `cp apps/api/.env.example apps/api/.env.local`, then:
 
 ```bash
-cp apps/api/.env.example apps/api/.env.local   # one-time: POSTGRES_URL → the app role
-pnpm db:up        # start Postgres (docker compose up -d)
+pnpm db:up        # start Postgres        ·   pnpm db:reset  # wipe + re-init
 pnpm db:migrate   # apply apps/api migrations (the authoritative schema)
-pnpm db:studio    # drizzle-kit studio    ·    pnpm db:psql    ·    pnpm db:logs
-pnpm db:reset     # wipe the volume and re-init (re-runs the app-role setup)
+pnpm db:studio    ·   pnpm db:psql   ·   pnpm db:logs
 ```
 
-Migrations run from the host against **`apps/api`** (authoritative). `apps/web` still
-uses its own PoC schema and is not yet wired to this database (cutover pending). The RLS
-moat can be re-proven end-to-end with `apps/api/scripts/rls-test.sh`.
+Dev provisions a non-superuser role so RLS (incl. `FORCE`) is exercised as in production — the role model, the per-request `app.current_user_id` requirement, and `scripts/rls-test.sh` are documented in [apps/api/AGENTS.md](apps/api/AGENTS.md). `apps/web` still uses its own PoC schema and isn't wired to this DB yet (cutover pending).
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,25 @@ pnpm format   # prettier --write **/*.{ts,tsx,md}
 
 Scope to one workspace with `pnpm --filter web <script>` (or `--filter api`).
 
+## Local database (docker)
+
+`compose.yaml` at the repo root runs Postgres for development. It provisions a
+**non-superuser `app` role that owns the schema**, so Row-Level Security (incl. `FORCE`)
+is exercised in dev exactly as in a self-hosted deployment — a superuser would silently
+bypass the multi-tenant moat.
+
+```bash
+cp apps/api/.env.example apps/api/.env.local   # one-time: POSTGRES_URL → the app role
+pnpm db:up        # start Postgres (docker compose up -d)
+pnpm db:migrate   # apply apps/api migrations (the authoritative schema)
+pnpm db:studio    # drizzle-kit studio    ·    pnpm db:psql    ·    pnpm db:logs
+pnpm db:reset     # wipe the volume and re-init (re-runs the app-role setup)
+```
+
+Migrations run from the host against **`apps/api`** (authoritative). `apps/web` still
+uses its own PoC schema and is not yet wired to this database (cutover pending). The RLS
+moat can be re-proven end-to-end with `apps/api/scripts/rls-test.sh`.
+
 ## Conventions
 
 - TypeScript only across web/api/worker — no second backend language (SPEC.md §23).

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,6 @@
+# apps/api environment — copy to .env.local for local dev:
+#   cp apps/api/.env.example apps/api/.env.local
+#
+# Points at the docker-compose Postgres (repo-root compose.yaml) and connects as the
+# non-superuser `app` role, so RLS/FORCE (the multi-tenant moat) is active in dev.
+POSTGRES_URL=postgres://app:app@localhost:5432/llame

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -25,11 +25,28 @@ pnpm --filter api db:migrate   # tsx src/db/migrate.ts
 pnpm --filter api db:studio    # drizzle-kit studio (also db:push / db:check)
 ```
 
+## Local database & RLS (dev)
+
+The repo-root `compose.yaml` runs Postgres for dev; root scripts wrap it (`pnpm db:up` /
+`db:migrate` / `db:studio` / `db:psql` / `db:reset`). One-time: `cp apps/api/.env.example
+apps/api/.env.local`.
+
+Migrations run as a **non-superuser `app` role that owns the schema** (provisioned by
+`docker/postgres/initdb/01-app-role.sql`), so RLS is exercised in dev as in production:
+
+- RLS is `ENABLE`d **and** `FORCE`d on `chats`/`messages`. Without `FORCE` the table owner
+  bypasses RLS, so a single-role self-hosted deployment would silently lose tenant isolation.
+- Every request must run inside `TenantDbService.runAs(userId, …)`, which sets
+  `app.current_user_id` transaction-locally. If it is unset, every RLS policy denies all rows.
+- `scripts/rls-test.sh` re-proves cross-tenant isolation against a throwaway Postgres
+  (non-superuser owner + FORCE). Run it after touching the schema, RLS, or `TenantDbService`.
+
 ## Conventions
 
 - One NestJS module per feature (controller / service / module); wire via DI and register in `app.module.ts`.
-- Schema lives in `src/db/schema`; change it, then `db:generate`. Never hand-edit migration SQL or `meta/_journal.json`.
+- Schema lives in `src/db/schema`; change it, then `db:generate`. Don't hand-edit generated migration SQL or `meta/_journal.json` — the sole exception (`0004`) is documented in Gotchas.
 
 ## Gotchas
 
 - Schema currently overlaps with `apps/web/lib/db` (the DB is being moved out of `web` into here) — keep the two from diverging until the move is finished.
+- Migrations are `drizzle-kit`-generated (`0005`+). Exception: `0004` (the PoC → multi-tenant transition) is hand-authored, because drizzle-kit's interactive column-rename prompt can't be driven non-interactively; `drizzle-kit check` passes. `FORCE ROW LEVEL SECURITY` is also hand-maintained in `0004` (Drizzle can't express it). Re-add both if you ever regenerate that migration.

--- a/apps/api/scripts/rls-test.sh
+++ b/apps/api/scripts/rls-test.sh
@@ -27,10 +27,16 @@ docker run -d --name "$CONTAINER" -e POSTGRES_PASSWORD=postgres \
   -p "${PORT}:5432" "$IMAGE" >/dev/null
 
 echo -n "▶ waiting for postgres"
+ready=false
 for _ in $(seq 1 60); do
-  if docker exec "$CONTAINER" pg_isready -U postgres >/dev/null 2>&1; then break; fi
+  if docker exec "$CONTAINER" pg_isready -U postgres >/dev/null 2>&1; then ready=true; break; fi
   echo -n "."; sleep 1
 done
+if [ "$ready" != true ]; then
+  echo " TIMEOUT"
+  echo "✗ postgres did not become ready within 60s" >&2
+  exit 1
+fi
 echo " ready"
 
 echo "▶ provisioning non-superuser owner role 'app'"

--- a/apps/api/scripts/rls-test.sh
+++ b/apps/api/scripts/rls-test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Prove the multi-tenant RLS moat (#53) against a real Postgres.
+#
+# Spins up a throwaway Postgres in docker, creates a NON-superuser role `app` that
+# OWNS the schema (the worst case for a self-hosted single-role deployment), applies
+# all migrations as that role, then runs the RLS integration suite connected as it.
+# A green run proves FORCE ROW LEVEL SECURITY is enforcing isolation even against the
+# table owner — ENABLE alone would let the owner bypass RLS and leak across tenants.
+#
+# Usage:  apps/api/scripts/rls-test.sh
+# Requires: docker.
+set -euo pipefail
+
+API_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTAINER=llame-rls-test
+PORT="${RLS_TEST_PORT:-55432}"
+IMAGE="${RLS_TEST_PG_IMAGE:-postgres:17-alpine}"
+APP_URL="postgres://app:app@localhost:${PORT}/llame_test"
+
+cleanup() { docker rm -f "$CONTAINER" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+cleanup
+
+echo "▶ starting $IMAGE on :$PORT"
+docker run -d --name "$CONTAINER" -e POSTGRES_PASSWORD=postgres \
+  -p "${PORT}:5432" "$IMAGE" >/dev/null
+
+echo -n "▶ waiting for postgres"
+for _ in $(seq 1 60); do
+  if docker exec "$CONTAINER" pg_isready -U postgres >/dev/null 2>&1; then break; fi
+  echo -n "."; sleep 1
+done
+echo " ready"
+
+echo "▶ provisioning non-superuser owner role 'app'"
+docker exec -i "$CONTAINER" psql -U postgres -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+CREATE ROLE app LOGIN PASSWORD 'app' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
+CREATE DATABASE llame_test OWNER app;
+SQL
+# app must own schema `public` to create tables in it (PG15+ locks this down).
+docker exec -i "$CONTAINER" psql -U postgres -d llame_test -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+ALTER SCHEMA public OWNER TO app;
+SQL
+
+echo "▶ applying migrations as 'app' (so app owns every table)"
+( cd "$API_DIR" && POSTGRES_URL="$APP_URL" pnpm db:migrate )
+
+echo "▶ running RLS integration suite as 'app'"
+( cd "$API_DIR" && TEST_DATABASE_URL="$APP_URL" pnpm exec jest chats-rls.integration --silent=false )
+
+echo "✓ RLS moat proven: cross-tenant isolation holds for a non-superuser table owner"

--- a/apps/api/src/chats/chats-repository.spec.ts
+++ b/apps/api/src/chats/chats-repository.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * ChatsRepository unit tests — owner-scoped query defense-in-depth.
+ *
+ * Uses a mock Drizzle db to verify that every repository method
+ * applies the owner filter. The RLS integration test (RLS actually enforcing
+ * cross-tenant isolation) lives in chats-rls.integration.spec.ts and requires
+ * a real PostgreSQL connection.
+ *
+ * Acceptance criteria covered:
+ * - every repository query is owner-scoped (defense-in-depth)
+ */
+
+import {
+  ChatsRepository,
+  MessagesRepository,
+  type Db,
+} from './chats-repository';
+
+// Minimal Drizzle-compatible mock factory
+function makeMockDb() {
+  // Terminal methods that resolve the query chain
+  const terminal = {
+    execute: jest.fn().mockResolvedValue([]),
+    returning: jest.fn().mockResolvedValue([]),
+  };
+
+  // Chainable query builder — each method returns an object with all methods + terminal
+  function chain(): Record<string, jest.Mock> {
+    const obj: Record<string, jest.Mock> = {};
+    const methods = ['from', 'where', 'orderBy', 'limit', 'values', 'set'];
+    methods.forEach((m) => {
+      obj[m] = jest.fn(() => ({ ...obj, ...terminal }));
+    });
+    return { ...obj, ...terminal };
+  }
+
+  const selectMock = jest.fn(() => chain());
+  const insertMock = jest.fn(() => chain());
+  const updateMock = jest.fn(() => chain());
+
+  const db = {
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+  };
+
+  return db as unknown as Db & {
+    select: jest.Mock;
+    insert: jest.Mock;
+    update: jest.Mock;
+  };
+}
+
+describe('ChatsRepository — owner-scoped queries (defense-in-depth)', () => {
+  const ownerUserId = 'owner-123';
+  const chatId = 'chat-abc';
+
+  it('findByOwner calls select (owner filter applied)', async () => {
+    const db = makeMockDb();
+    const repo = new ChatsRepository(db);
+
+    await repo.findByOwner(ownerUserId).catch(() => null);
+
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('findById calls select (ownership check + chatId filter)', async () => {
+    const db = makeMockDb();
+    const repo = new ChatsRepository(db);
+
+    await repo.findById(chatId, ownerUserId).catch(() => null);
+
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('create calls insert with ownerUserId', async () => {
+    const db = makeMockDb();
+    const repo = new ChatsRepository(db);
+
+    await repo.create({ ownerUserId, title: 'Test Chat' }).catch(() => null);
+
+    expect(db.insert).toHaveBeenCalled();
+  });
+
+  it('updateTitle calls update with chatId and ownerUserId', async () => {
+    const db = makeMockDb();
+    const repo = new ChatsRepository(db);
+
+    await repo.updateTitle(chatId, ownerUserId, 'New Title').catch(() => null);
+
+    expect(db.update).toHaveBeenCalled();
+  });
+});
+
+describe('MessagesRepository — chat-scoped queries', () => {
+  it('findByChatId calls select', async () => {
+    const db = makeMockDb();
+    const repo = new MessagesRepository(db);
+
+    await repo.findByChatId('chat-1').catch(() => null);
+
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('create calls insert with chatId and senderUserId', async () => {
+    const db = makeMockDb();
+    const repo = new MessagesRepository(db);
+
+    await repo
+      .create({
+        chatId: 'chat-1',
+        role: 'user',
+        senderUserId: 'user-1',
+        parts: [{ type: 'text', text: 'Hello' }],
+      })
+      .catch(() => null);
+
+    expect(db.insert).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/chats/chats-repository.spec.ts
+++ b/apps/api/src/chats/chats-repository.spec.ts
@@ -1,120 +1,149 @@
 /**
- * ChatsRepository unit tests — owner-scoped query defense-in-depth.
+ * ChatsRepository / MessagesRepository unit tests — owner-scoped defense-in-depth.
  *
- * Uses a mock Drizzle db to verify that every repository method
- * applies the owner filter. The RLS integration test (RLS actually enforcing
- * cross-tenant isolation) lives in chats-rls.integration.spec.ts and requires
- * a real PostgreSQL connection.
+ * These assert the owner-scoping is actually present in the query payload, not just
+ * that a query was issued: inserts carry ownerUserId in `.values`, and read/update
+ * `.where` conditions reference the owner id. Removing the owner filter fails these.
  *
- * Acceptance criteria covered:
- * - every repository query is owner-scoped (defense-in-depth)
+ * Real RLS enforcement (cross-tenant isolation) is proven against a live Postgres in
+ * chats-rls.integration.spec.ts.
  */
 
+import { PgDialect } from 'drizzle-orm/pg-core';
 import {
   ChatsRepository,
   MessagesRepository,
   type Db,
 } from './chats-repository';
 
-// Minimal Drizzle-compatible mock factory
+// Mock Drizzle db that records the arguments passed to where/values/set so tests can
+// assert the scoping appears in the payload. Chain methods return the same object so
+// any call order resolves; terminal methods resolve empty.
 function makeMockDb() {
-  // Terminal methods that resolve the query chain
+  const whereSpy = jest.fn();
+  const valuesSpy = jest.fn();
+  const setSpy = jest.fn();
   const terminal = {
     execute: jest.fn().mockResolvedValue([]),
     returning: jest.fn().mockResolvedValue([]),
   };
 
-  // Chainable query builder — each method returns an object with all methods + terminal
   function chain(): Record<string, jest.Mock> {
     const obj: Record<string, jest.Mock> = {};
-    const methods = ['from', 'where', 'orderBy', 'limit', 'values', 'set'];
-    methods.forEach((m) => {
+    ['from', 'innerJoin', 'orderBy', 'limit'].forEach((m) => {
       obj[m] = jest.fn(() => ({ ...obj, ...terminal }));
+    });
+    obj.where = jest.fn((arg: unknown) => {
+      whereSpy(arg);
+      return { ...obj, ...terminal };
+    });
+    obj.values = jest.fn((arg: unknown) => {
+      valuesSpy(arg);
+      return { ...obj, ...terminal };
+    });
+    obj.set = jest.fn((arg: unknown) => {
+      setSpy(arg);
+      return { ...obj, ...terminal };
     });
     return { ...obj, ...terminal };
   }
 
-  const selectMock = jest.fn(() => chain());
-  const insertMock = jest.fn(() => chain());
-  const updateMock = jest.fn(() => chain());
-
   const db = {
-    select: selectMock,
-    insert: insertMock,
-    update: updateMock,
+    select: jest.fn(() => chain()),
+    insert: jest.fn(() => chain()),
+    update: jest.fn(() => chain()),
   };
 
-  return db as unknown as Db & {
-    select: jest.Mock;
-    insert: jest.Mock;
-    update: jest.Mock;
+  return {
+    db: db as unknown as Db & {
+      select: jest.Mock;
+      insert: jest.Mock;
+      update: jest.Mock;
+    },
+    whereSpy,
+    valuesSpy,
+    setSpy,
   };
+}
+
+// Drizzle wraps bound values in Params; compile each captured where-condition to
+// SQL + params via the real dialect and assert the id is a bound parameter.
+const dialect = new PgDialect();
+function whereContains(whereSpy: jest.Mock, value: string): boolean {
+  return whereSpy.mock.calls.some((call: unknown[]) => {
+    try {
+      return dialect.sqlToQuery(call[0] as never).params.includes(value);
+    } catch {
+      return false;
+    }
+  });
 }
 
 describe('ChatsRepository — owner-scoped queries (defense-in-depth)', () => {
   const ownerUserId = 'owner-123';
   const chatId = 'chat-abc';
 
-  it('findByOwner calls select (owner filter applied)', async () => {
-    const db = makeMockDb();
-    const repo = new ChatsRepository(db);
-
-    await repo.findByOwner(ownerUserId).catch(() => null);
-
+  it('findByOwner filters by ownerUserId', async () => {
+    const { db, whereSpy } = makeMockDb();
+    await new ChatsRepository(db).findByOwner(ownerUserId).catch(() => null);
     expect(db.select).toHaveBeenCalled();
+    expect(whereContains(whereSpy, ownerUserId)).toBe(true);
   });
 
-  it('findById calls select (ownership check + chatId filter)', async () => {
-    const db = makeMockDb();
-    const repo = new ChatsRepository(db);
-
-    await repo.findById(chatId, ownerUserId).catch(() => null);
-
-    expect(db.select).toHaveBeenCalled();
+  it('findById scopes by chatId AND ownerUserId', async () => {
+    const { db, whereSpy } = makeMockDb();
+    await new ChatsRepository(db)
+      .findById(chatId, ownerUserId)
+      .catch(() => null);
+    expect(whereContains(whereSpy, ownerUserId)).toBe(true);
+    expect(whereContains(whereSpy, chatId)).toBe(true);
   });
 
-  it('create calls insert with ownerUserId', async () => {
-    const db = makeMockDb();
-    const repo = new ChatsRepository(db);
-
-    await repo.create({ ownerUserId, title: 'Test Chat' }).catch(() => null);
-
-    expect(db.insert).toHaveBeenCalled();
+  it('create inserts a row carrying ownerUserId', async () => {
+    const { db, valuesSpy } = makeMockDb();
+    await new ChatsRepository(db)
+      .create({ ownerUserId, title: 'Test Chat' })
+      .catch(() => null);
+    expect(valuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId }),
+    );
   });
 
-  it('updateTitle calls update with chatId and ownerUserId', async () => {
-    const db = makeMockDb();
-    const repo = new ChatsRepository(db);
-
-    await repo.updateTitle(chatId, ownerUserId, 'New Title').catch(() => null);
-
-    expect(db.update).toHaveBeenCalled();
+  it('updateTitle scopes the update by chatId AND ownerUserId', async () => {
+    const { db, whereSpy } = makeMockDb();
+    await new ChatsRepository(db)
+      .updateTitle(chatId, ownerUserId, 'New Title')
+      .catch(() => null);
+    expect(whereContains(whereSpy, ownerUserId)).toBe(true);
+    expect(whereContains(whereSpy, chatId)).toBe(true);
   });
 });
 
-describe('MessagesRepository — chat-scoped queries', () => {
-  it('findByChatId calls select', async () => {
-    const db = makeMockDb();
-    const repo = new MessagesRepository(db);
+describe('MessagesRepository — owner-scoped + chat-scoped', () => {
+  const ownerUserId = 'owner-xyz';
+  const chatId = 'chat-1';
 
-    await repo.findByChatId('chat-1').catch(() => null);
-
-    expect(db.select).toHaveBeenCalled();
+  it('findByChatId scopes by chatId AND ownerUserId (join to chats.owner_user_id)', async () => {
+    const { db, whereSpy } = makeMockDb();
+    await new MessagesRepository(db)
+      .findByChatId(chatId, ownerUserId)
+      .catch(() => null);
+    expect(whereContains(whereSpy, ownerUserId)).toBe(true);
+    expect(whereContains(whereSpy, chatId)).toBe(true);
   });
 
-  it('create calls insert with chatId and senderUserId', async () => {
-    const db = makeMockDb();
-    const repo = new MessagesRepository(db);
-
-    await repo
+  it('create inserts carrying chatId and senderUserId', async () => {
+    const { db, valuesSpy } = makeMockDb();
+    await new MessagesRepository(db)
       .create({
-        chatId: 'chat-1',
+        chatId,
         role: 'user',
         senderUserId: 'user-1',
         parts: [{ type: 'text', text: 'Hello' }],
       })
       .catch(() => null);
-
-    expect(db.insert).toHaveBeenCalled();
+    expect(valuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId, senderUserId: 'user-1' }),
+    );
   });
 });

--- a/apps/api/src/chats/chats-repository.ts
+++ b/apps/api/src/chats/chats-repository.ts
@@ -91,18 +91,34 @@ export class MessagesRepository {
   constructor(private readonly db: Db) {}
 
   /**
-   * List messages for a chat, oldest-first (for context window ordering).
-   * Caller must have already verified chat ownership (RLS + ChatsRepository.findById).
+   * List a chat's messages oldest-first, ordered by `seq` (the monotonic
+   * insertion key — created_at ties for same-transaction writes).
+   *
+   * Owner-scoped as defense-in-depth: the inner join requires the chat to be owned
+   * by `ownerUserId`, so a caller that forgets the RLS-scoped transaction still
+   * cannot read another tenant's messages. RLS remains the primary guarantee.
    */
-  async findByChatId(chatId: string): Promise<Message[]> {
-    return this.db
+  async findByChatId(chatId: string, ownerUserId: string): Promise<Message[]> {
+    const rows = await this.db
       .select()
       .from(messages)
-      .where(eq(messages.chatId, chatId))
-      .orderBy(asc(messages.createdAt));
+      .innerJoin(chats, eq(messages.chatId, chats.id))
+      .where(
+        and(eq(messages.chatId, chatId), eq(chats.ownerUserId, ownerUserId)),
+      )
+      .orderBy(asc(messages.seq));
+
+    return rows.map((r) => r.messages);
   }
 
-  /** Append a message to a chat. */
+  /**
+   * Append a message to a chat.
+   *
+   * Write ownership is enforced by RLS: the `messages_owner` policy's check rejects
+   * an insert whose `chat_id` is not owned by the current `app.current_user_id`, and
+   * the `chat_id` FK guarantees the chat exists. (No app-layer owner pre-check here —
+   * it would be a redundant round-trip; the RLS WITH CHECK is atomic.)
+   */
   async create(input: {
     chatId: string;
     role: MessageRole;

--- a/apps/api/src/chats/chats-repository.ts
+++ b/apps/api/src/chats/chats-repository.ts
@@ -1,0 +1,126 @@
+/**
+ * ChatsRepository and MessagesRepository — owner-scoped database access.
+ *
+ * Every query filters by ownerUserId / chatId as defense-in-depth.
+ * RLS is the primary isolation guarantee; these filters are the seatbelt.
+ *
+ * The `db` parameter accepts a PostgresJsDatabase from drizzle-orm/postgres-js.
+ * It is typed loosely here so it can be injected by NestJS DI or mocked in tests.
+ */
+
+import { and, asc, desc, eq } from 'drizzle-orm';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../db/schema';
+import {
+  type Chat,
+  type Message,
+  type MessageRole,
+  chats,
+  messages,
+} from '../db/schema';
+
+export type Db = PostgresJsDatabase<typeof schema>;
+
+export class ChatsRepository {
+  constructor(private readonly db: Db) {}
+
+  /** List chats owned by a user, newest-first by updatedAt. */
+  async findByOwner(ownerUserId: string): Promise<Chat[]> {
+    return this.db
+      .select()
+      .from(chats)
+      .where(eq(chats.ownerUserId, ownerUserId))
+      .orderBy(desc(chats.updatedAt));
+  }
+
+  /**
+   * Find a single chat by id, requiring ownership match (defense-in-depth).
+   * Returns undefined if not found or not owned by this user.
+   */
+  async findById(
+    chatId: string,
+    ownerUserId: string,
+  ): Promise<Chat | undefined> {
+    const rows = await this.db
+      .select()
+      .from(chats)
+      .where(and(eq(chats.id, chatId), eq(chats.ownerUserId, ownerUserId)))
+      .limit(1);
+
+    return rows[0];
+  }
+
+  /** Create a new chat owned by a user. */
+  async create(input: {
+    ownerUserId: string;
+    title?: string;
+    visibility?: 'private' | 'public';
+  }): Promise<Chat> {
+    const [created] = await this.db
+      .insert(chats)
+      .values({
+        ownerUserId: input.ownerUserId,
+        title: input.title ?? 'New chat',
+        visibility: input.visibility ?? 'private',
+      })
+      .returning();
+
+    return created;
+  }
+
+  /**
+   * Update a chat's title, scoped to owner (defense-in-depth).
+   * Returns undefined if not found or not owned by this user.
+   */
+  async updateTitle(
+    chatId: string,
+    ownerUserId: string,
+    title: string,
+  ): Promise<Chat | undefined> {
+    const [updated] = await this.db
+      .update(chats)
+      .set({ title, updatedAt: new Date() })
+      .where(and(eq(chats.id, chatId), eq(chats.ownerUserId, ownerUserId)))
+      .returning();
+
+    return updated;
+  }
+}
+
+export class MessagesRepository {
+  constructor(private readonly db: Db) {}
+
+  /**
+   * List messages for a chat, oldest-first (for context window ordering).
+   * Caller must have already verified chat ownership (RLS + ChatsRepository.findById).
+   */
+  async findByChatId(chatId: string): Promise<Message[]> {
+    return this.db
+      .select()
+      .from(messages)
+      .where(eq(messages.chatId, chatId))
+      .orderBy(asc(messages.createdAt));
+  }
+
+  /** Append a message to a chat. */
+  async create(input: {
+    chatId: string;
+    role: MessageRole;
+    senderUserId?: string | null;
+    parts: unknown[];
+    attachments?: unknown[];
+  }): Promise<Message> {
+    const [created] = await this.db
+      .insert(messages)
+      .values({
+        chatId: input.chatId,
+        role: input.role,
+        senderUserId: input.senderUserId ?? null,
+        parts: input.parts,
+        attachments: input.attachments ?? [],
+      })
+      .returning();
+
+    return created;
+  }
+}

--- a/apps/api/src/chats/chats-rls.integration.spec.ts
+++ b/apps/api/src/chats/chats-rls.integration.spec.ts
@@ -172,7 +172,7 @@ describeIfDb('RLS integration — cross-tenant isolation under FORCE', () => {
       });
       expect(created.parts).toEqual(parts);
 
-      const [readBack] = await messagesRepo.findByChatId(chat.id);
+      const [readBack] = await messagesRepo.findByChatId(chat.id, userAId);
       expect(readBack.parts).toEqual(parts);
 
       await tx.execute(dsql`DELETE FROM chats WHERE id = ${chat.id}`); // cascades to messages
@@ -223,7 +223,9 @@ describeIfDb(
       const postgres = require('postgres');
       const connect = postgres.default ?? postgres;
       const ssl = /sslmode=require/.test(TEST_DB_URL!) ? 'require' : false;
-      sql = connect(TEST_DB_URL!, { ssl, max: 1 });
+      // max: 2 (see first describe block) so afterAll cleanup can't deadlock against
+      // an open transaction on a single pooled connection.
+      sql = connect(TEST_DB_URL!, { ssl, max: 2 });
       db = drizzle(sql, { schema });
       svc = new ChatsService(new TenantDbService(db));
 

--- a/apps/api/src/chats/chats-rls.integration.spec.ts
+++ b/apps/api/src/chats/chats-rls.integration.spec.ts
@@ -19,6 +19,7 @@
  * - SET LOCAL app.current_user_id correctly scopes reads
  * - cross-tenant read returns zero rows (chats and messages)
  * - messages.parts round-trips AI SDK v5 UIMessage parts (write→read equality)
+ * - ChatsService.runAs engages RLS at the app layer (service-level isolation test)
  *
  * NOTE: this file uses `any` for the postgres.js client, loaded dynamically so the
  * module does not connect at import time when TEST_DATABASE_URL is absent.
@@ -38,6 +39,8 @@ import {
   MessagesRepository,
   type Db,
 } from './chats-repository';
+import { TenantDbService } from '../db/tenant-db.service';
+import { ChatsService } from './chats.service';
 
 const TEST_DB_URL = process.env['TEST_DATABASE_URL'];
 const describeIfDb = TEST_DB_URL ? describe : describe.skip;
@@ -194,3 +197,72 @@ describeIfDb('RLS integration — cross-tenant isolation under FORCE', () => {
     }
   });
 });
+
+/**
+ * Service-level RLS integration — proves the APP layer (ChatsService via
+ * TenantDbService.runAs) correctly engages RLS for tenant isolation.
+ *
+ * This is the acceptance criterion: "ChatsService.createChat({ownerUserId: A})
+ * succeeds; getChatsByUserId(A) returns it; getChatsByUserId(B) returns zero
+ * of A's chats."
+ */
+describeIfDb(
+  'ChatsService — app-layer RLS engagement via TenantDbService.runAs',
+  () => {
+    let sql: SqlClient;
+    let db: Db;
+    let svc: ChatsService;
+    let userAId: string;
+    let userBId: string;
+
+    beforeAll(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const postgres = require('postgres');
+      const connect = postgres.default ?? postgres;
+      const ssl = /sslmode=require/.test(TEST_DB_URL!) ? 'require' : false;
+      sql = connect(TEST_DB_URL!, { ssl, max: 1 });
+      db = drizzle(sql, { schema });
+      svc = new ChatsService(new TenantDbService(db));
+
+      userAId = crypto.randomUUID();
+      userBId = crypto.randomUUID();
+      await sql`INSERT INTO users (id, name, email) VALUES (${userAId}, 'Svc User A', ${`svc-a-${userAId}@test.com`})`;
+      await sql`INSERT INTO users (id, name, email) VALUES (${userBId}, 'Svc User B', ${`svc-b-${userBId}@test.com`})`;
+    });
+
+    afterAll(async () => {
+      if (sql) {
+        await sql`DELETE FROM users WHERE id IN (${userAId}, ${userBId})`;
+        await sql.end();
+      }
+    });
+
+    it('createChat + getChatsByUserId(A) returns the chat created by A', async () => {
+      const chat = await svc.createChat({
+        ownerUserId: userAId,
+        title: 'Service Chat A',
+      });
+
+      expect(chat.id).toBeDefined();
+      expect(chat.ownerUserId).toBe(userAId);
+
+      const aChats = await svc.getChatsByUserId(userAId);
+      const found = aChats.find((c) => c.id === chat.id);
+      expect(found).toBeDefined();
+      expect(found?.ownerUserId).toBe(userAId);
+    });
+
+    it('getChatsByUserId(B) returns zero of A chats (cross-tenant isolation via runAs)', async () => {
+      const chat = await svc.createChat({
+        ownerUserId: userAId,
+        title: 'A-Only Chat',
+      });
+
+      const bChats = await svc.getChatsByUserId(userBId);
+      const leaked = bChats.find((c) => c.id === chat.id);
+
+      // B must not see A's chat — this proves RLS is engaged at the service layer.
+      expect(leaked).toBeUndefined();
+    });
+  },
+);

--- a/apps/api/src/chats/chats-rls.integration.spec.ts
+++ b/apps/api/src/chats/chats-rls.integration.spec.ts
@@ -72,9 +72,12 @@ describeIfDb('RLS integration — cross-tenant isolation under FORCE', () => {
     const connect = postgres.default ?? postgres;
     // Local test databases (docker) have no TLS; only require it if the URL asks.
     const ssl = /sslmode=require/.test(TEST_DB_URL!) ? 'require' : false;
-    sql = connect(TEST_DB_URL!, { ssl, max: 1 });
-    // Drizzle client over the same connection — used to round-trip through the
-    // actual production repository code path (not hand-rolled SQL).
+    // max: 2 (not 1) so beforeAll/afterAll raw-sql cleanup never deadlocks against a
+    // still-open runAs transaction — with a single pooled connection, a tx left open
+    // by a failing test would block afterAll's DELETE and hang the process in CI.
+    sql = connect(TEST_DB_URL!, { ssl, max: 2 });
+    // Drizzle client over the same pool — used to round-trip through the actual
+    // production repository code path (not hand-rolled SQL).
     db = drizzle(sql, { schema });
 
     // users has no RLS, so the owner can seed it directly (no scope needed).

--- a/apps/api/src/chats/chats-rls.integration.spec.ts
+++ b/apps/api/src/chats/chats-rls.integration.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * RLS integration tests — requires a real PostgreSQL connection.
+ *
+ * Set TEST_DATABASE_URL to a connection string to run. The connecting role MUST be:
+ *   - NOT a superuser and NOT BYPASSRLS (those bypass RLS unconditionally), and
+ *   - ideally the OWNER of the chats/messages tables — that is the worst case for a
+ *     self-hosted deployment (one Postgres role owns, migrates, AND serves the app).
+ *     RLS only constrains a table owner when FORCE ROW LEVEL SECURITY is set, so a
+ *     green run as the owner proves FORCE is doing its job.
+ *
+ * Example (matches scripts/rls-test.sh, which provisions exactly this):
+ *   TEST_DATABASE_URL="postgres://app:app@localhost:55432/llame_test" pnpm --filter api test
+ *
+ * If TEST_DATABASE_URL is not set, all tests in this file are skipped.
+ *
+ * Acceptance criteria covered (#53):
+ * - RLS ENABLED *and* FORCED on chats + messages
+ * - the connecting role is non-superuser (otherwise the test would be meaningless)
+ * - SET LOCAL app.current_user_id correctly scopes reads
+ * - cross-tenant read returns zero rows (chats and messages)
+ * - messages.parts round-trips AI SDK v5 UIMessage parts (write→read equality)
+ *
+ * NOTE: this file uses `any` for the postgres.js client, loaded dynamically so the
+ * module does not connect at import time when TEST_DATABASE_URL is absent.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+import { sql as dsql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import * as schema from '../db/schema';
+import {
+  ChatsRepository,
+  MessagesRepository,
+  type Db,
+} from './chats-repository';
+
+const TEST_DB_URL = process.env['TEST_DATABASE_URL'];
+const describeIfDb = TEST_DB_URL ? describe : describe.skip;
+
+type SqlClient = any;
+
+describeIfDb('RLS integration — cross-tenant isolation under FORCE', () => {
+  let sql: SqlClient;
+  let db: Db;
+  let userAId: string;
+  let userBId: string;
+
+  /**
+   * Run `fn` inside a transaction scoped to `userId` via app.current_user_id.
+   * Uses set_config(..., is_local = true) — the parameterizable equivalent of
+   * `SET LOCAL` (plain `SET LOCAL x = $1` cannot take a bind parameter). This
+   * mirrors what the request layer must do for every chats/messages query.
+   */
+  const asUser = (userId: string, fn: (tx: SqlClient) => Promise<any>) =>
+    sql.begin(async (tx: SqlClient) => {
+      await tx`SELECT set_config('app.current_user_id', ${userId}, true)`;
+      return fn(tx);
+    });
+
+  beforeAll(async () => {
+    // Dynamic import to avoid connecting at module load time.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const postgres = require('postgres');
+    const connect = postgres.default ?? postgres;
+    // Local test databases (docker) have no TLS; only require it if the URL asks.
+    const ssl = /sslmode=require/.test(TEST_DB_URL!) ? 'require' : false;
+    sql = connect(TEST_DB_URL!, { ssl, max: 1 });
+    // Drizzle client over the same connection — used to round-trip through the
+    // actual production repository code path (not hand-rolled SQL).
+    db = drizzle(sql, { schema });
+
+    // users has no RLS, so the owner can seed it directly (no scope needed).
+    userAId = crypto.randomUUID();
+    userBId = crypto.randomUUID();
+    await sql`INSERT INTO users (id, name, email) VALUES (${userAId}, 'User A', ${`test-a-${userAId}@test.com`})`;
+    await sql`INSERT INTO users (id, name, email) VALUES (${userBId}, 'User B', ${`test-b-${userBId}@test.com`})`;
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      // chats/messages cascade from users; deleting the users is enough, but those
+      // deletes touch chats under FORCE, so scope each cleanup to its owner.
+      await sql`DELETE FROM users WHERE id IN (${userAId}, ${userBId})`;
+      await sql.end();
+    }
+  });
+
+  it('the harness is meaningful: non-superuser role, RLS ENABLED + FORCED on both tables', async () => {
+    const [role] =
+      await sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`;
+    // A superuser or BYPASSRLS role would make every assertion below vacuous.
+    expect(role.rolsuper).toBe(false);
+    expect(role.rolbypassrls).toBe(false);
+
+    const rows = await sql`
+      SELECT relname, relrowsecurity, relforcerowsecurity
+      FROM pg_class
+      WHERE relname IN ('chats', 'messages')
+      ORDER BY relname`;
+    expect(rows.length).toBe(2);
+    for (const r of rows) {
+      expect(r.relrowsecurity).toBe(true); // ENABLE
+      expect(r.relforcerowsecurity).toBe(true); // FORCE — the load-bearing bit
+    }
+  });
+
+  it('owner A can create and read their own chat', async () => {
+    const chatId = crypto.randomUUID();
+    await asUser(userAId, async (tx) => {
+      await tx`INSERT INTO chats (id, owner_user_id, title) VALUES (${chatId}, ${userAId}, 'Chat A')`;
+      const rows = await tx`SELECT id FROM chats WHERE id = ${chatId}`;
+      expect(rows.length).toBe(1);
+      expect(rows[0].id).toBe(chatId);
+      await tx`DELETE FROM chats WHERE id = ${chatId}`;
+    });
+  });
+
+  it('cross-tenant read: owner B cannot see owner A chat (zero rows)', async () => {
+    const chatId = crypto.randomUUID();
+    await asUser(
+      userAId,
+      (tx) =>
+        tx`INSERT INTO chats (id, owner_user_id, title) VALUES (${chatId}, ${userAId}, 'Private A')`,
+    );
+    try {
+      const rows = await asUser(
+        userBId,
+        (tx) => tx`SELECT id FROM chats WHERE id = ${chatId}`,
+      );
+      expect(rows.length).toBe(0);
+    } finally {
+      await asUser(userAId, (tx) => tx`DELETE FROM chats WHERE id = ${chatId}`);
+    }
+  });
+
+  it('messages.parts round-trips AI SDK v5 UIMessage parts via the real repository (write→read equality)', async () => {
+    // Exercises the PRODUCTION code path (Drizzle jsonb) inside an RLS-scoped
+    // transaction — not hand-rolled SQL — so this proves the column round-trips
+    // structured parts exactly as the app writes them.
+    const parts = [
+      { type: 'text', text: 'Hello round-trip' },
+      { type: 'reasoning', text: 'thinking…', extra: { nested: [1, 2, 3] } },
+    ];
+
+    await db.transaction(async (tx) => {
+      await tx.execute(
+        dsql`select set_config('app.current_user_id', ${userAId}, true)`,
+      );
+      const chatsRepo = new ChatsRepository(tx as unknown as Db);
+      const messagesRepo = new MessagesRepository(tx as unknown as Db);
+
+      const chat = await chatsRepo.create({
+        ownerUserId: userAId,
+        title: 'RT',
+      });
+      const created = await messagesRepo.create({
+        chatId: chat.id,
+        role: 'user',
+        senderUserId: userAId,
+        parts,
+      });
+      expect(created.parts).toEqual(parts);
+
+      const [readBack] = await messagesRepo.findByChatId(chat.id);
+      expect(readBack.parts).toEqual(parts);
+
+      await tx.execute(dsql`DELETE FROM chats WHERE id = ${chat.id}`); // cascades to messages
+    });
+  });
+
+  it('messages cross-tenant: owner B cannot see owner A messages (zero rows)', async () => {
+    const chatId = crypto.randomUUID();
+    const msgId = crypto.randomUUID();
+
+    await asUser(userAId, async (tx) => {
+      await tx`INSERT INTO chats (id, owner_user_id, title) VALUES (${chatId}, ${userAId}, 'Private Chat')`;
+      await tx`
+        INSERT INTO messages (id, chat_id, role, parts)
+        VALUES (${msgId}, ${chatId}, 'assistant', ${JSON.stringify([{ type: 'text', text: 'secret' }])})`;
+    });
+    try {
+      const rows = await asUser(
+        userBId,
+        (tx) => tx`SELECT id FROM messages WHERE id = ${msgId}`,
+      );
+      expect(rows.length).toBe(0);
+    } finally {
+      await asUser(userAId, (tx) => tx`DELETE FROM chats WHERE id = ${chatId}`);
+    }
+  });
+});

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -1,7 +1,24 @@
-import { Controller, Get, Param, Post, Body, Put } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Body,
+  Put,
+  Query,
+  NotFoundException,
+} from '@nestjs/common';
 import { ChatsService } from './chats.service';
 import { Chat } from '../db/schema';
 
+/**
+ * SECURITY (v0.1, pre-auth): `ownerUserId` is currently taken from client input
+ * (params/body). That means it sets the RLS tenant identity from caller-supplied
+ * data — a client could read/write another tenant by passing a different id. These
+ * endpoints are dev scaffolding and MUST NOT be exposed until `ownerUserId` is
+ * derived from a verified auth session/guard (separate follow-up). RLS + owner-scoped
+ * repositories are defense-in-depth, not a substitute for trusted identity.
+ */
 @Controller('chats')
 export class ChatsController {
   constructor(private readonly chatsService: ChatsService) {}
@@ -13,12 +30,18 @@ export class ChatsController {
     return this.chatsService.getChatsByUserId(ownerUserId);
   }
 
+  // ownerUserId via @Query, not @Body: GET request bodies are dropped by many
+  // clients, caches, and proxies, so a @Body() value arrives undefined in practice.
   @Get(':id')
   async getChatById(
     @Param('id') id: string,
-    @Body() { ownerUserId }: { ownerUserId: string },
-  ): Promise<Chat | undefined> {
-    return this.chatsService.getChatById(id, ownerUserId);
+    @Query('ownerUserId') ownerUserId: string,
+  ): Promise<Chat> {
+    const chat = await this.chatsService.getChatById(id, ownerUserId);
+    if (!chat) {
+      throw new NotFoundException(`Chat ${id} not found`);
+    }
+    return chat;
   }
 
   @Post()
@@ -32,7 +55,15 @@ export class ChatsController {
   async updateChatTitle(
     @Param('id') id: string,
     @Body() { ownerUserId, title }: { ownerUserId: string; title: string },
-  ): Promise<Chat | undefined> {
-    return this.chatsService.updateChatTitle(id, ownerUserId, title);
+  ): Promise<Chat> {
+    const chat = await this.chatsService.updateChatTitle(
+      id,
+      ownerUserId,
+      title,
+    );
+    if (!chat) {
+      throw new NotFoundException(`Chat ${id} not found`);
+    }
+    return chat;
   }
 }

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -6,32 +6,33 @@ import { Chat } from '../db/schema';
 export class ChatsController {
   constructor(private readonly chatsService: ChatsService) {}
 
-  @Get('user/:userId')
-  async getChatsByUserId(@Param('userId') userId: string): Promise<Chat[]> {
-    return this.chatsService.getChatsByUserId(userId);
+  @Get('owner/:ownerUserId')
+  async getChatsByOwner(
+    @Param('ownerUserId') ownerUserId: string,
+  ): Promise<Chat[]> {
+    return this.chatsService.getChatsByUserId(ownerUserId);
   }
 
   @Get(':id')
-  async getChatById(@Param('id') id: string): Promise<Chat | undefined> {
-    return this.chatsService.getChatById(id);
+  async getChatById(
+    @Param('id') id: string,
+    @Body() { ownerUserId }: { ownerUserId: string },
+  ): Promise<Chat | undefined> {
+    return this.chatsService.getChatById(id, ownerUserId);
   }
 
   @Post()
   async createChat(
-    @Body() chatData: { userId: string; title: string; createdAt?: Date },
+    @Body() chatData: { ownerUserId: string; title?: string },
   ): Promise<Chat> {
     return this.chatsService.createChat(chatData);
   }
 
-  @Put(':id/last-message')
-  async updateChatLastMessage(
+  @Put(':id/title')
+  async updateChatTitle(
     @Param('id') id: string,
-    @Body() { lastMessageAt }: { lastMessageAt: string | Date },
+    @Body() { ownerUserId, title }: { ownerUserId: string; title: string },
   ): Promise<Chat | undefined> {
-    const date =
-      typeof lastMessageAt === 'string'
-        ? new Date(lastMessageAt)
-        : lastMessageAt;
-    return this.chatsService.updateChatLastMessage(id, date);
+    return this.chatsService.updateChatTitle(id, ownerUserId, title);
   }
 }

--- a/apps/api/src/chats/chats.module.ts
+++ b/apps/api/src/chats/chats.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TenantDbService } from '../db/tenant-db.service';
 import { ChatsController } from './chats.controller';
 import { ChatsService } from './chats.service';
 
 @Module({
   controllers: [ChatsController],
-  providers: [ChatsService],
+  providers: [TenantDbService, ChatsService],
   exports: [ChatsService],
 })
 export class ChatsModule {}

--- a/apps/api/src/chats/chats.service.ts
+++ b/apps/api/src/chats/chats.service.ts
@@ -1,66 +1,40 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { desc, eq } from 'drizzle-orm';
 import * as schema from '../db/schema';
-import { Chat, chats } from '../db/schema';
+import { type Chat } from '../db/schema';
+import { ChatsRepository } from './chats-repository';
 
 @Injectable()
 export class ChatsService {
-  constructor(
-    @Inject('DB_DEV') private db: PostgresJsDatabase<typeof schema>,
-  ) {}
+  private readonly chatsRepo: ChatsRepository;
+
+  constructor(@Inject('DB_DEV') private db: PostgresJsDatabase<typeof schema>) {
+    this.chatsRepo = new ChatsRepository(db);
+  }
 
   async getChatsByUserId(userId: string): Promise<Chat[]> {
-    const userChats = await this.db
-      .select()
-      .from(chats)
-      .where(eq(chats.userId, userId))
-      .orderBy(desc(chats.lastMessageAt), desc(chats.createdAt));
-
-    return userChats.length ? userChats : [];
+    return this.chatsRepo.findByOwner(userId);
   }
 
-  async getChatById(chatId: string): Promise<Chat | undefined> {
-    const chat = await this.db
-      .select()
-      .from(chats)
-      .where(eq(chats.id, chatId))
-      .limit(1);
-
-    return chat.length ? chat[0] : undefined;
-  }
-
-  async createChat({
-    userId,
-    title,
-    createdAt,
-  }: {
-    userId: string;
-    title: string;
-    createdAt?: Date;
-  }): Promise<Chat> {
-    const [newChat] = await this.db
-      .insert(chats)
-      .values({
-        userId,
-        title,
-        createdAt: createdAt ?? new Date(),
-      })
-      .returning();
-
-    return newChat;
-  }
-
-  async updateChatLastMessage(
+  async getChatById(
     chatId: string,
-    lastMessageAt: Date,
+    ownerUserId: string,
   ): Promise<Chat | undefined> {
-    const [updatedChat] = await this.db
-      .update(chats)
-      .set({ lastMessageAt })
-      .where(eq(chats.id, chatId))
-      .returning();
+    return this.chatsRepo.findById(chatId, ownerUserId);
+  }
 
-    return updatedChat;
+  async createChat(input: {
+    ownerUserId: string;
+    title?: string;
+  }): Promise<Chat> {
+    return this.chatsRepo.create(input);
+  }
+
+  async updateChatTitle(
+    chatId: string,
+    ownerUserId: string,
+    title: string,
+  ): Promise<Chat | undefined> {
+    return this.chatsRepo.updateTitle(chatId, ownerUserId, title);
   }
 }

--- a/apps/api/src/chats/chats.service.ts
+++ b/apps/api/src/chats/chats.service.ts
@@ -1,33 +1,34 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import * as schema from '../db/schema';
+import { Injectable } from '@nestjs/common';
 import { type Chat } from '../db/schema';
+import { TenantDbService } from '../db/tenant-db.service';
 import { ChatsRepository } from './chats-repository';
 
 @Injectable()
 export class ChatsService {
-  private readonly chatsRepo: ChatsRepository;
-
-  constructor(@Inject('DB_DEV') private db: PostgresJsDatabase<typeof schema>) {
-    this.chatsRepo = new ChatsRepository(db);
-  }
+  constructor(private readonly tenantDb: TenantDbService) {}
 
   async getChatsByUserId(userId: string): Promise<Chat[]> {
-    return this.chatsRepo.findByOwner(userId);
+    return this.tenantDb.runAs(userId, (tx) =>
+      new ChatsRepository(tx).findByOwner(userId),
+    );
   }
 
   async getChatById(
     chatId: string,
     ownerUserId: string,
   ): Promise<Chat | undefined> {
-    return this.chatsRepo.findById(chatId, ownerUserId);
+    return this.tenantDb.runAs(ownerUserId, (tx) =>
+      new ChatsRepository(tx).findById(chatId, ownerUserId),
+    );
   }
 
   async createChat(input: {
     ownerUserId: string;
     title?: string;
   }): Promise<Chat> {
-    return this.chatsRepo.create(input);
+    return this.tenantDb.runAs(input.ownerUserId, (tx) =>
+      new ChatsRepository(tx).create(input),
+    );
   }
 
   async updateChatTitle(
@@ -35,6 +36,8 @@ export class ChatsService {
     ownerUserId: string,
     title: string,
   ): Promise<Chat | undefined> {
-    return this.chatsRepo.updateTitle(chatId, ownerUserId, title);
+    return this.tenantDb.runAs(ownerUserId, (tx) =>
+      new ChatsRepository(tx).updateTitle(chatId, ownerUserId, title),
+    );
   }
 }

--- a/apps/api/src/chats/context-builder.spec.ts
+++ b/apps/api/src/chats/context-builder.spec.ts
@@ -10,13 +10,17 @@
 
 import { buildContext, type StoredMessage } from './context-builder';
 
-// Minimal message factory
+// Minimal message factory. `seq` auto-increments in creation order, which matches
+// the intended conversation order of the fixtures below; override it to test
+// out-of-order input.
+let seqCounter = 0;
 function msg(
   overrides: Partial<StoredMessage> & Pick<StoredMessage, 'role' | 'parts'>,
 ): StoredMessage {
   return {
     id: 'msg-' + Math.random().toString(36).slice(2),
     chatId: 'chat-1',
+    seq: ++seqCounter,
     senderUserId: null,
     attachments: [],
     createdAt: new Date('2024-01-01T00:00:00Z'),
@@ -97,6 +101,17 @@ describe('buildContext', () => {
       expect(result[1].role).toBe('user');
       expect(result[2].role).toBe('assistant');
       expect(result[3].role).toBe('user');
+    });
+
+    it('normalizes unsorted input by seq before building (sort-before-cap)', () => {
+      // Same messages, shuffled. seq order is userMsg1(1) → assistantMsg1(2) → userMsg2(3).
+      const result = buildContext([userMsg2, userMsg1, assistantMsg1], {
+        systemPrompt,
+      });
+
+      expect(result[1].content).toContain('Hello'); // userMsg1
+      expect(result[2].content).toContain('Hi there!'); // assistantMsg1
+      expect(result[3].content).toContain('How are you?'); // userMsg2
     });
   });
 

--- a/apps/api/src/chats/context-builder.spec.ts
+++ b/apps/api/src/chats/context-builder.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * ContextBuilder unit tests — pure functions, no DB required.
+ *
+ * Acceptance criteria covered:
+ * - stable prefix is byte-identical across turns (cache-stability)
+ * - deterministic output for identical inputs
+ * - sender attribution rendered when >1 distinct senderUserId
+ * - single-sender chat produces no sender prefix
+ */
+
+import { buildContext, type StoredMessage } from './context-builder';
+
+// Minimal message factory
+function msg(
+  overrides: Partial<StoredMessage> & Pick<StoredMessage, 'role' | 'parts'>,
+): StoredMessage {
+  return {
+    id: 'msg-' + Math.random().toString(36).slice(2),
+    chatId: 'chat-1',
+    senderUserId: null,
+    attachments: [],
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('buildContext', () => {
+  const systemPrompt = 'You are a helpful assistant.';
+
+  const userMsg1 = msg({
+    id: 'msg-1',
+    role: 'user',
+    senderUserId: 'user-alice',
+    parts: [{ type: 'text', text: 'Hello' }],
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+  });
+
+  const assistantMsg1 = msg({
+    id: 'msg-2',
+    role: 'assistant',
+    senderUserId: null,
+    parts: [{ type: 'text', text: 'Hi there!' }],
+    createdAt: new Date('2024-01-01T00:00:01Z'),
+  });
+
+  const userMsg2 = msg({
+    id: 'msg-3',
+    role: 'user',
+    senderUserId: 'user-alice',
+    parts: [{ type: 'text', text: 'How are you?' }],
+    createdAt: new Date('2024-01-01T00:00:02Z'),
+  });
+
+  describe('cache-stability: stable prefix is byte-identical across turns', () => {
+    it('system message content is identical regardless of which turn is current', () => {
+      const turn1 = buildContext([userMsg1], { systemPrompt });
+      const turn2 = buildContext([userMsg1, assistantMsg1], { systemPrompt });
+      const turn3 = buildContext([userMsg1, assistantMsg1, userMsg2], {
+        systemPrompt,
+      });
+
+      // The first element (system message) must be byte-identical across all turns
+      const sys1 = JSON.stringify(turn1[0]);
+      const sys2 = JSON.stringify(turn2[0]);
+      const sys3 = JSON.stringify(turn3[0]);
+
+      expect(sys1).toBe(sys2);
+      expect(sys2).toBe(sys3);
+    });
+
+    it('stable prefix contains no timestamps, ids, or per-request values', () => {
+      const result = buildContext([userMsg1], { systemPrompt });
+      const systemContent = JSON.stringify(result[0]);
+
+      // Must not contain any message IDs or timestamps
+      expect(systemContent).not.toContain('msg-1');
+      expect(systemContent).not.toContain('2024-01-01');
+      expect(systemContent).not.toContain('chat-1');
+    });
+  });
+
+  describe('determinism', () => {
+    it('identical inputs produce identical output', () => {
+      const messages = [userMsg1, assistantMsg1, userMsg2];
+      const out1 = buildContext(messages, { systemPrompt });
+      const out2 = buildContext(messages, { systemPrompt });
+
+      expect(JSON.stringify(out1)).toBe(JSON.stringify(out2));
+    });
+
+    it('message order is oldest-first (history order preserved)', () => {
+      const messages = [userMsg1, assistantMsg1, userMsg2];
+      const result = buildContext(messages, { systemPrompt });
+
+      // system prompt first, then messages in order
+      expect(result[0].role).toBe('system');
+      expect(result[1].role).toBe('user');
+      expect(result[2].role).toBe('assistant');
+      expect(result[3].role).toBe('user');
+    });
+  });
+
+  describe('sender attribution', () => {
+    it('no sender prefix when only one distinct senderUserId in chat', () => {
+      const messages = [userMsg1, assistantMsg1, userMsg2];
+      const result = buildContext(messages, { systemPrompt });
+
+      const userMessages = result.filter((m) => m.role === 'user');
+      userMessages.forEach((m) => {
+        const textPart = m.content;
+        expect(textPart).not.toContain('Alice:');
+        expect(textPart).not.toContain('user-alice:');
+      });
+    });
+
+    it('renders sender attribution prefix when >1 distinct senderUserId', () => {
+      const bobMsg = msg({
+        id: 'msg-bob',
+        role: 'user',
+        senderUserId: 'user-bob',
+        parts: [{ type: 'text', text: 'Hey from Bob' }],
+        createdAt: new Date('2024-01-01T00:00:03Z'),
+      });
+
+      const messages = [userMsg1, assistantMsg1, bobMsg];
+      const result = buildContext(messages, { systemPrompt });
+
+      const userMessages = result.filter((m) => m.role === 'user');
+      // At least one message should have a sender prefix
+      const hasSenderPrefix = userMessages.some((m) => {
+        const content =
+          typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+        return (
+          content.includes('[user-alice]') ||
+          content.includes('[user-bob]') ||
+          content.includes('user-alice:') ||
+          content.includes('user-bob:')
+        );
+      });
+
+      expect(hasSenderPrefix).toBe(true);
+    });
+
+    it('assistant/system/tool messages never get sender prefix', () => {
+      const bobMsg = msg({
+        id: 'msg-bob',
+        role: 'user',
+        senderUserId: 'user-bob',
+        parts: [{ type: 'text', text: 'Hey' }],
+        createdAt: new Date('2024-01-01T00:00:03Z'),
+      });
+      const messages = [userMsg1, assistantMsg1, bobMsg];
+      const result = buildContext(messages, { systemPrompt });
+
+      const assistantMessages = result.filter((m) => m.role === 'assistant');
+      assistantMessages.forEach((m) => {
+        const content =
+          typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+        expect(content).not.toContain('[');
+      });
+    });
+  });
+
+  describe('parts round-trip', () => {
+    it('text parts are preserved in message content', () => {
+      const messages = [userMsg1];
+      const result = buildContext(messages, { systemPrompt });
+
+      const userResult = result.find((m) => m.role === 'user');
+      const content =
+        typeof userResult!.content === 'string'
+          ? userResult!.content
+          : JSON.stringify(userResult!.content);
+
+      expect(content).toContain('Hello');
+    });
+  });
+
+  describe('token budget / hard cap', () => {
+    it('respects max messages cap: keeps most-recent-N messages within budget', () => {
+      // Generate 200 messages — more than any reasonable limit
+      const manyMessages: StoredMessage[] = Array.from(
+        { length: 200 },
+        (_, i) =>
+          msg({
+            id: `msg-${i}`,
+            role: i % 2 === 0 ? 'user' : 'assistant',
+            senderUserId: i % 2 === 0 ? 'user-alice' : null,
+            parts: [{ type: 'text', text: `Message ${i}` }],
+            createdAt: new Date(Date.now() + i * 1000),
+          }),
+      );
+
+      const result = buildContext(manyMessages, {
+        systemPrompt,
+        maxMessages: 10,
+      });
+
+      // system prompt + at most 10 messages
+      expect(result.length).toBeLessThanOrEqual(11);
+      expect(result[0].role).toBe('system');
+    });
+  });
+});

--- a/apps/api/src/chats/context-builder.ts
+++ b/apps/api/src/chats/context-builder.ts
@@ -1,0 +1,122 @@
+/**
+ * ContextBuilder — turns a chat's stored messages into the model input array.
+ *
+ * Design contract (SPEC §53):
+ * - Cache-aware order: [stable system prefix] → [history oldest→newest]
+ * - Stable prefix contains NO timestamps, ids, or per-request values — byte-identical across turns
+ * - Sender attribution prefix applied when >1 distinct senderUserId in the chat
+ * - Deterministic: identical inputs → identical output
+ * - Hard cap (maxMessages) keeps most-recent-N messages within token budget
+ *   Lineage-based compaction is issue #57.
+ */
+
+/** AI SDK v5 UIMessage part shape (text part — the common case). */
+export interface TextPart {
+  type: 'text';
+  text: string;
+}
+
+/** Union of AI SDK v5 UIMessage parts. Extend as more part types are added. */
+export type MessagePart = TextPart | Record<string, unknown>;
+
+/**
+ * The subset of a stored DB message that ContextBuilder needs.
+ * Mirrors the `messages` table columns used here.
+ */
+export interface StoredMessage {
+  id: string;
+  chatId: string;
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  senderUserId: string | null;
+  parts: MessagePart[];
+  attachments: unknown[];
+  createdAt: Date;
+}
+
+/** Minimal AI SDK v5 model message shape. */
+export interface ModelMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+}
+
+export interface BuildContextOptions {
+  systemPrompt: string;
+  /**
+   * Maximum number of messages to include (most-recent-N).
+   * Hard cap: keeps the context within a token budget.
+   * Default: 100. Lineage-based compaction is issue #57.
+   */
+  maxMessages?: number;
+}
+
+const DEFAULT_MAX_MESSAGES = 100;
+
+/**
+ * Extracts the text content from an AI SDK v5 UIMessage parts array.
+ * Non-text parts are serialised as JSON so nothing is silently dropped.
+ */
+function partsToText(parts: MessagePart[]): string {
+  return parts
+    .map((p) => {
+      if ('type' in p && p.type === 'text' && 'text' in p) {
+        return (p as TextPart).text;
+      }
+      return JSON.stringify(p);
+    })
+    .join('\n');
+}
+
+/**
+ * Build the model input array from a chat's stored messages.
+ *
+ * Order: [system] → [history oldest→newest (trimmed to maxMessages)]
+ *
+ * The system message is always first and contains ONLY the static systemPrompt
+ * so it is byte-identical across turns and prompt-cache-friendly.
+ */
+export function buildContext(
+  messages: StoredMessage[],
+  options: BuildContextOptions,
+): ModelMessage[] {
+  const { systemPrompt, maxMessages = DEFAULT_MAX_MESSAGES } = options;
+
+  // Determine if sender attribution is needed (>1 distinct human sender)
+  const senderIds = new Set(
+    messages
+      .filter((m) => m.role === 'user' && m.senderUserId !== null)
+      .map((m) => m.senderUserId as string),
+  );
+  const multiSender = senderIds.size > 1;
+
+  // Apply hard cap: keep the most-recent N messages
+  const trimmed =
+    messages.length > maxMessages
+      ? messages.slice(messages.length - maxMessages)
+      : messages;
+
+  // Build message array
+  const result: ModelMessage[] = [
+    // Stable system prefix — MUST contain no per-request data
+    { role: 'system', content: systemPrompt },
+  ];
+
+  for (const m of trimmed) {
+    const baseContent = partsToText(m.parts);
+
+    let content: string;
+    if (multiSender && m.role === 'user' && m.senderUserId !== null) {
+      // Sender attribution: prefix with sender id so the model can attribute turns.
+      // Content is treated as data, not instruction (SPEC §28.2 trust boundary).
+      content = `[${m.senderUserId}] ${baseContent}`;
+    } else {
+      content = baseContent;
+    }
+
+    result.push({
+      role: m.role === 'tool' ? 'tool' : m.role,
+      content,
+    });
+  }
+
+  return result;
+}

--- a/apps/api/src/chats/context-builder.ts
+++ b/apps/api/src/chats/context-builder.ts
@@ -26,6 +26,10 @@ export type MessagePart = TextPart | Record<string, unknown>;
 export interface StoredMessage {
   id: string;
   chatId: string;
+  // Monotonic insertion-order key (messages.seq). Used to order history
+  // deterministically — created_at is the transaction timestamp and ties for
+  // messages written in the same transaction.
+  seq: number;
   role: 'user' | 'assistant' | 'system' | 'tool';
   senderUserId: string | null;
   parts: MessagePart[];
@@ -33,7 +37,17 @@ export interface StoredMessage {
   createdAt: Date;
 }
 
-/** Minimal AI SDK v5 model message shape. */
+/**
+ * Minimal model message shape for v0.1.
+ *
+ * NOTE (v0.1 simplification): `content` is a flattened string. This is sufficient
+ * for the text-only Q&A loop and is NOT the full AI SDK `ModelMessage`/`CoreMessage`
+ * shape — assistant/tool messages there carry structured `content` arrays
+ * (tool-call / tool-result parts). When the real model layer is wired in (#54),
+ * this type aligns with the AI SDK and `assistant`/`tool` roles preserve structured
+ * parts instead of being stringified by `partsToText`. No tools exist in v0.1, so
+ * flattening loses nothing today.
+ */
 export interface ModelMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content: string;
@@ -88,11 +102,17 @@ export function buildContext(
   );
   const multiSender = senderIds.size > 1;
 
+  // Deterministic order: sort by seq (monotonic insertion order) BEFORE trimming,
+  // so the hard cap keeps the most-recent-N by conversation order even if the
+  // caller passed an unsorted array. seq (not createdAt) because same-transaction
+  // messages share created_at — see messages.seq in the schema.
+  const ordered = [...messages].sort((a, b) => a.seq - b.seq);
+
   // Apply hard cap: keep the most-recent N messages
   const trimmed =
-    messages.length > maxMessages
-      ? messages.slice(messages.length - maxMessages)
-      : messages;
+    ordered.length > maxMessages
+      ? ordered.slice(ordered.length - maxMessages)
+      : ordered;
 
   // Build message array
   const result: ModelMessage[] = [

--- a/apps/api/src/db/migrations/0004_v01_chat_message_schema.sql
+++ b/apps/api/src/db/migrations/0004_v01_chat_message_schema.sql
@@ -1,0 +1,102 @@
+-- Migration: v0.1 multi-tenant chat + message schema (issue #53)
+--
+-- Drops the PoC chats + messages tables and recreates them with:
+--   - chats.owner_user_id (replaces user_id) + visibility + updatedAt
+--   - messages: uuid primary key, role enum, senderUserId (nullable), parts (jsonb),
+--     attachments (jsonb), createdAt with timezone
+--   - Row-Level Security on both tables
+--   - Indexes: (owner_user_id, updated_at) on chats, (chat_id, created_at) on messages
+--
+-- MANUAL MIGRATION NOTE: drizzle-kit generate requires interactive TTY input to
+-- resolve column rename ambiguity (user_id → owner_user_id). Since this is a
+-- full table replacement rather than a rename, this migration was hand-authored
+-- to correctly DROP and recreate both tables. The Drizzle schema in
+-- src/db/schema/chats.ts is authoritative and matches this SQL exactly.
+--
+-- The app DB role must NOT be BYPASSRLS or a superuser. Each request must run:
+--   SET LOCAL app.current_user_id = '<user-id>';
+-- inside a transaction before any chats/messages query.
+
+-- Drop PoC tables (messages first to satisfy FK)
+DROP TABLE IF EXISTS "messages";
+--> statement-breakpoint
+DROP TABLE IF EXISTS "chats";
+--> statement-breakpoint
+
+-- New message_role enum
+DO $$ BEGIN
+  CREATE TYPE "public"."message_role" AS ENUM('user', 'assistant', 'system', 'tool');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+
+-- chats: multi-tenant, owner-scoped
+CREATE TABLE "chats" (
+  "id"             uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "owner_user_id"  text NOT NULL,
+  "title"          text NOT NULL DEFAULT 'New chat',
+  "visibility"     varchar NOT NULL DEFAULT 'private',
+  "created_at"     timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at"     timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+-- messages: AI SDK v5 UIMessage shape, sender-attributed
+CREATE TABLE "messages" (
+  "id"              uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "chat_id"         uuid NOT NULL,
+  "role"            "message_role" NOT NULL,
+  "sender_user_id"  text,
+  "parts"           jsonb NOT NULL,
+  "attachments"     jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "created_at"      timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+-- Foreign keys
+ALTER TABLE "chats" ADD CONSTRAINT "chats_owner_user_id_users_id_fk"
+  FOREIGN KEY ("owner_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_chat_id_chats_id_fk"
+  FOREIGN KEY ("chat_id") REFERENCES "public"."chats"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_sender_user_id_users_id_fk"
+  FOREIGN KEY ("sender_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+
+-- Indexes
+CREATE INDEX "chats_owner_updated_idx" ON "chats" ("owner_user_id", "updated_at");
+--> statement-breakpoint
+CREATE INDEX "messages_chat_created_idx" ON "messages" ("chat_id", "created_at");
+--> statement-breakpoint
+
+-- Row-Level Security
+-- ENABLE turns RLS on; FORCE makes it apply to the table OWNER too. Without FORCE,
+-- a self-hosted deployment that runs the app on the same Postgres role that owns
+-- (and migrates) these tables would silently bypass RLS entirely — the moat would
+-- be off even with `app.current_user_id` set. FORCE closes that. (Superusers and
+-- BYPASSRLS roles still bypass RLS regardless — the app role must be neither.)
+ALTER TABLE "chats" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "chats" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "messages" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "messages" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+-- RLS policy: chats visible only to their owner
+-- Uses text = text comparison (owner_user_id is text, matching users.id which is text)
+CREATE POLICY "chats_owner" ON "chats"
+  USING (owner_user_id = current_setting('app.current_user_id', true));
+--> statement-breakpoint
+
+-- RLS policy: messages visible only when their chat is owned by the current user
+CREATE POLICY "messages_owner" ON "messages"
+  USING (
+    chat_id IN (
+      SELECT id FROM chats
+      WHERE owner_user_id = current_setting('app.current_user_id', true)
+    )
+  );

--- a/apps/api/src/db/migrations/0005_bouncy_zarek.sql
+++ b/apps/api/src/db/migrations/0005_bouncy_zarek.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."chat_visibility" AS ENUM('private', 'public');--> statement-breakpoint
+ALTER TABLE "chats" ALTER COLUMN "visibility" SET DEFAULT 'private'::"public"."chat_visibility";--> statement-breakpoint
+ALTER TABLE "chats" ALTER COLUMN "visibility" SET DATA TYPE "public"."chat_visibility" USING "visibility"::"public"."chat_visibility";--> statement-breakpoint
+ALTER TABLE "messages" ADD COLUMN "seq" bigint NOT NULL GENERATED ALWAYS AS IDENTITY (sequence name "messages_seq_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1);--> statement-breakpoint
+CREATE INDEX "messages_chat_seq_idx" ON "messages" USING btree ("chat_id","seq");

--- a/apps/api/src/db/migrations/meta/0004_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,562 @@
+{
+  "id": "4d4d94f6-ff06-4873-9808-26c340853653",
+  "prevId": "f0cd74ec-302f-4b39-967b-1cc4522e19d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "typeSchema": "pg_catalog",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_owner_updated_idx": {
+          "name": "chats_owner_updated_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_owner_user_id_users_id_fk": {
+          "name": "chats_owner_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {
+        "chats_owner": {
+          "name": "chats_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "owner_user_id = current_setting('app.current_user_id', true)"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "typeSchema": "pg_catalog",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_created_idx": {
+          "name": "messages_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_user_id_users_id_fk": {
+          "name": "messages_sender_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "schemaTo": "public",
+          "columnsFrom": [
+            "sender_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {},
+      "policies": {
+        "messages_owner": {
+          "name": "messages_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "chat_id IN (\n        SELECT id FROM chats\n        WHERE owner_user_id = current_setting('app.current_user_id', true)\n      )"
+        }
+      },
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/0005_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,604 @@
+{
+  "id": "47dec181-cc9e-47fd-ae73-d2a7712550ab",
+  "prevId": "4d4d94f6-ff06-4873-9808-26c340853653",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "chat_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_owner_updated_idx": {
+          "name": "chats_owner_updated_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_owner_user_id_users_id_fk": {
+          "name": "chats_owner_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "chats_owner": {
+          "name": "chats_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "owner_user_id = current_setting('app.current_user_id', true)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "messages_seq_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_created_idx": {
+          "name": "messages_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_chat_seq_idx": {
+          "name": "messages_chat_seq_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_user_id_users_id_fk": {
+          "name": "messages_sender_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "messages_owner": {
+          "name": "messages_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "chat_id IN (\n        SELECT id FROM chats\n        WHERE owner_user_id = current_setting('app.current_user_id', true)\n      )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.chat_visibility": {
+      "name": "chat_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1751700000000,
       "tag": "0004_v01_chat_message_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1782735542694,
+      "tag": "0005_bouncy_zarek",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1752640526507,
       "tag": "0003_modern_red_hulk",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1751700000000,
+      "tag": "0004_v01_chat_message_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/chats.ts
+++ b/apps/api/src/db/schema/chats.ts
@@ -1,35 +1,102 @@
 import { InferSelectModel } from 'drizzle-orm';
-import { timestamp, pgTable, text, jsonb } from 'drizzle-orm/pg-core';
+import {
+  index,
+  jsonb,
+  pgEnum,
+  pgPolicy,
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { users } from './auth';
-import { v7 } from 'uuid';
 
-export const chats = pgTable('chats', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  userId: text('user_id')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
-  title: text('title').notNull(),
-  createdAt: timestamp('created_at', { mode: 'date' }).notNull(),
-  lastMessageAt: timestamp('last_message_at', { mode: 'date' }),
-});
+// A conversation. `ownerUserId` is the tenant boundary for v0.1.
+// (Org-owned chats add a nullable `orgId` in v0.3 — additive, not a retrofit.)
+//
+// NOTE: ownerUserId uses `text` (not `uuid`) because it references `users.id`
+// which is a `text` column (NextAuth adapter convention). chats.id itself uses
+// `uuid` since it is a new table with no legacy constraint.
+export const chats = pgTable(
+  'chats',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // text — FK to users.id which is text (NextAuth convention)
+    ownerUserId: text('owner_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    title: text('title').notNull().default('New chat'),
+    visibility: varchar('visibility', { enum: ['private', 'public'] })
+      .notNull()
+      .default('private'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index('chats_owner_updated_idx').on(t.ownerUserId, t.updatedAt),
+    // RLS policy: text = text comparison (no ::uuid cast — owner_user_id is text).
+    // NOTE: `.enableRLS()` only emits ENABLE. The migration ALSO issues
+    // `FORCE ROW LEVEL SECURITY` on both tables, which Drizzle cannot express here
+    // (no force option in this version). FORCE is load-bearing for the single-role
+    // self-hosted case — see migration 0004 and the relforcerowsecurity assertion in
+    // chats-rls.integration.spec.ts. If you regenerate this migration, re-add FORCE.
+    pgPolicy('chats_owner', {
+      using: sql`owner_user_id = current_setting('app.current_user_id', true)`,
+    }),
+  ],
+).enableRLS();
 
 export type Chat = InferSelectModel<typeof chats>;
 
-export type MessageRole = 'user' | 'assistant';
+export const messageRole = pgEnum('message_role', [
+  'user',
+  'assistant',
+  'system',
+  'tool',
+]);
 
-export const messages = pgTable('messages', {
-  id: text('id')
-    .primaryKey()
-    .$defaultFn(() => v7()),
-  chatId: text('chat_id')
-    .notNull()
-    .references(() => chats.id, { onDelete: 'cascade' }),
-  userId: text('user_id')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
-  content: jsonb('content').notNull(),
-});
+// A durable conversation turn (AI SDK v5 UIMessage shape) with sender attribution.
+//
+// senderUserId is nullable: set for human turns; null for assistant/system/tool.
+// Resolves to a CANONICAL user (SPEC §7.1, §19.2).
+// text — FK to users.id which is text (NextAuth convention).
+export const messages = pgTable(
+  'messages',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    chatId: uuid('chat_id')
+      .notNull()
+      .references(() => chats.id, { onDelete: 'cascade' }),
+    role: messageRole('role').notNull(),
+    // nullable: set for human turns; null for assistant/system/tool
+    senderUserId: text('sender_user_id').references(() => users.id),
+    parts: jsonb('parts').notNull(), // AI SDK v5 UIMessage parts array
+    attachments: jsonb('attachments')
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index('messages_chat_created_idx').on(t.chatId, t.createdAt),
+    // RLS: access messages only when their chat is owned by the current user
+    pgPolicy('messages_owner', {
+      using: sql`chat_id IN (
+        SELECT id FROM chats
+        WHERE owner_user_id = current_setting('app.current_user_id', true)
+      )`,
+    }),
+  ],
+).enableRLS();
 
 export type Message = InferSelectModel<typeof messages>;
+
+// Re-export enum type for use in repository / service layer
+export type MessageRole = (typeof messageRole.enumValues)[number];

--- a/apps/api/src/db/schema/chats.ts
+++ b/apps/api/src/db/schema/chats.ts
@@ -1,5 +1,6 @@
 import { InferSelectModel } from 'drizzle-orm';
 import {
+  bigint,
   index,
   jsonb,
   pgEnum,
@@ -8,10 +9,13 @@ import {
   text,
   timestamp,
   uuid,
-  varchar,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { users } from './auth';
+
+// DB-enforced visibility values (not just a TS-level varchar union, which Postgres
+// would not constrain).
+export const chatVisibility = pgEnum('chat_visibility', ['private', 'public']);
 
 // A conversation. `ownerUserId` is the tenant boundary for v0.1.
 // (Org-owned chats add a nullable `orgId` in v0.3 — additive, not a retrofit.)
@@ -28,9 +32,7 @@ export const chats = pgTable(
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
     title: text('title').notNull().default('New chat'),
-    visibility: varchar('visibility', { enum: ['private', 'public'] })
-      .notNull()
-      .default('private'),
+    visibility: chatVisibility('visibility').notNull().default('private'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -73,9 +75,19 @@ export const messages = pgTable(
     chatId: uuid('chat_id')
       .notNull()
       .references(() => chats.id, { onDelete: 'cascade' }),
+    // Monotonic insertion-order key. `created_at` defaults to now() = the TRANSACTION
+    // timestamp, so messages written in one transaction (e.g. a user turn + its
+    // assistant reply) share an identical created_at and cannot be ordered by it
+    // deterministically. `seq` gives a stable conversation order; queries and the
+    // ContextBuilder order by it, not by created_at.
+    seq: bigint('seq', { mode: 'number' }).generatedAlwaysAsIdentity(),
     role: messageRole('role').notNull(),
-    // nullable: set for human turns; null for assistant/system/tool
-    senderUserId: text('sender_user_id').references(() => users.id),
+    // nullable: set for human turns; null for assistant/system/tool.
+    // onDelete: set null — deleting a user anonymizes their past messages rather
+    // than blocking the delete or cascading away conversation history.
+    senderUserId: text('sender_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
     parts: jsonb('parts').notNull(), // AI SDK v5 UIMessage parts array
     attachments: jsonb('attachments')
       .notNull()
@@ -86,6 +98,8 @@ export const messages = pgTable(
   },
   (t) => [
     index('messages_chat_created_idx').on(t.chatId, t.createdAt),
+    // Ordering index: history is read with ORDER BY (chat_id, seq).
+    index('messages_chat_seq_idx').on(t.chatId, t.seq),
     // RLS: access messages only when their chat is owned by the current user
     pgPolicy('messages_owner', {
       using: sql`chat_id IN (

--- a/apps/api/src/db/tenant-db.service.spec.ts
+++ b/apps/api/src/db/tenant-db.service.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * TenantDbService unit tests.
+ *
+ * Proves that runAs:
+ *  1. opens a transaction
+ *  2. issues set_config('app.current_user_id', <userId>, true) as the first
+ *     statement inside that transaction
+ *  3. delegates to the caller-supplied callback with the tx handle
+ *  4. returns the callback's result
+ *
+ * Uses a spy/mock fake db — no real Postgres connection required.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { TenantDbService, type Db } from './tenant-db.service';
+
+function makeFakeDb() {
+  const executeSpy = jest.fn().mockResolvedValue([]);
+
+  const fakeTx = {
+    execute: executeSpy,
+  } as unknown as Db;
+
+  const transactionSpy = jest.fn((fn: (tx: Db) => Promise<unknown>) =>
+    fn(fakeTx),
+  );
+
+  const db = {
+    transaction: transactionSpy,
+  } as unknown as Db;
+
+  return { db, fakeTx, executeSpy, transactionSpy };
+}
+
+describe('TenantDbService.runAs', () => {
+  const userId = 'user-abc-123';
+
+  it('opens a transaction', async () => {
+    const { db, transactionSpy } = makeFakeDb();
+    const svc = new TenantDbService(db);
+
+    await svc.runAs(userId, () => Promise.resolve(undefined));
+
+    expect(transactionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls set_config with the userId as a transaction-local setting (is_local = true)', async () => {
+    const { db, executeSpy } = makeFakeDb();
+    const svc = new TenantDbService(db);
+
+    await svc.runAs(userId, () => Promise.resolve(undefined));
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+
+    // Inspect the SQL fragment for the bound param value.
+    // drizzle sql`` tag serialises to JSON that includes the param — check userId is present.
+
+    const executedSql: unknown = executeSpy.mock.calls[0][0];
+    const hasUserId = JSON.stringify(executedSql).includes(userId);
+    expect(hasUserId).toBe(true);
+  });
+
+  it('passes the tx handle into the callback', async () => {
+    const { db, fakeTx } = makeFakeDb();
+    const svc = new TenantDbService(db);
+    let capturedTx: unknown;
+
+    await svc.runAs(userId, (tx) => {
+      capturedTx = tx;
+      return Promise.resolve(undefined);
+    });
+
+    expect(capturedTx).toBe(fakeTx);
+  });
+
+  it('returns the result from the callback', async () => {
+    const { db } = makeFakeDb();
+    const svc = new TenantDbService(db);
+
+    const result = await svc.runAs(userId, () => Promise.resolve(42));
+
+    expect(result).toBe(42);
+  });
+});

--- a/apps/api/src/db/tenant-db.service.spec.ts
+++ b/apps/api/src/db/tenant-db.service.spec.ts
@@ -13,6 +13,7 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { TenantDbService, type Db } from './tenant-db.service';
 
 function makeFakeDb() {
@@ -45,7 +46,7 @@ describe('TenantDbService.runAs', () => {
     expect(transactionSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('calls set_config with the userId as a transaction-local setting (is_local = true)', async () => {
+  it('calls set_config(app.current_user_id, userId, true) — key, value, and is_local all correct', async () => {
     const { db, executeSpy } = makeFakeDb();
     const svc = new TenantDbService(db);
 
@@ -53,12 +54,18 @@ describe('TenantDbService.runAs', () => {
 
     expect(executeSpy).toHaveBeenCalledTimes(1);
 
-    // Inspect the SQL fragment for the bound param value.
-    // drizzle sql`` tag serialises to JSON that includes the param — check userId is present.
+    // Compile the executed statement to SQL + params via the real dialect, so the
+    // assertion fails if the config KEY changes or is_local is flipped to false —
+    // not just if the userId happens to appear somewhere.
+    const dialect = new PgDialect();
+    const { sql: compiled, params } = dialect.sqlToQuery(
+      executeSpy.mock.calls[0][0] as never,
+    );
 
-    const executedSql: unknown = executeSpy.mock.calls[0][0];
-    const hasUserId = JSON.stringify(executedSql).includes(userId);
-    expect(hasUserId).toBe(true);
+    expect(compiled).toContain('set_config');
+    expect(compiled).toContain('app.current_user_id');
+    expect(compiled).toContain('true'); // is_local = true (transaction-local)
+    expect(params).toContain(userId); // userId bound as a parameter
   });
 
   it('passes the tx handle into the callback', async () => {

--- a/apps/api/src/db/tenant-db.service.ts
+++ b/apps/api/src/db/tenant-db.service.ts
@@ -1,0 +1,47 @@
+/**
+ * TenantDbService — per-request RLS-scoped transaction helper.
+ *
+ * Wraps every unit of work in a single transaction that sets
+ * `app.current_user_id` transaction-locally (via set_config with is_local=true),
+ * engaging PostgreSQL Row-Level Security for the duration.
+ *
+ * Usage:
+ *   const result = await this.tenantDb.runAs(userId, (tx) =>
+ *     new ChatsRepository(tx).findByOwner(userId),
+ *   );
+ *
+ * NOTE: repos must be constructed inside the callback with the scoped `tx`,
+ * NOT stored on the service — the set_config is only live inside that transaction.
+ *
+ * TODO: wire userId from a request-scoped auth guard/interceptor once authentication
+ * is added to apps/api. For now, callers supply it explicitly from handler inputs.
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from './schema';
+
+export type Db = PostgresJsDatabase<typeof schema>;
+
+@Injectable()
+export class TenantDbService {
+  constructor(@Inject('DB_DEV') private readonly db: Db) {}
+
+  /**
+   * Run `fn` inside a transaction scoped to `userId`.
+   *
+   * set_config(..., true) is the parameterizable equivalent of `SET LOCAL` —
+   * plain `SET LOCAL x = $1` cannot accept a bind parameter in PostgreSQL.
+   * Passing `true` as the third argument makes the setting local to the current
+   * transaction, so it is automatically reverted on commit/rollback.
+   */
+  runAs<T>(userId: string, fn: (tx: Db) => Promise<T>): Promise<T> {
+    return this.db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select set_config('app.current_user_id', ${userId}, true)`,
+      );
+      return fn(tx as unknown as Db);
+    });
+  }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,38 @@
+# Local development database for llame.
+#
+# Provisions Postgres with a NON-superuser `app` role that OWNS the schema, so
+# Row-Level Security — including FORCE — is exercised in dev exactly as in a
+# self-hosted deployment. A superuser (or the default owner without FORCE) would
+# silently bypass RLS and disable the multi-tenant moat (#53).
+#
+# Quickstart:
+#   cp apps/api/.env.example apps/api/.env.local   # one-time
+#   pnpm db:up                                      # start Postgres
+#   pnpm db:migrate                                 # apply apps/api migrations
+#
+# Migrations are run from the host (apps/api is the authoritative schema; apps/web
+# still uses its own PoC schema until the cutover). See AGENTS.md › Local database.
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: llame-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: llame
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - llame-pgdata:/var/lib/postgresql/data
+      # Runs ONCE on a fresh volume (as the postgres superuser) to create the app role.
+      - ./docker/postgres/initdb:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d llame"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  llame-pgdata:

--- a/docker/postgres/initdb/01-app-role.sql
+++ b/docker/postgres/initdb/01-app-role.sql
@@ -1,0 +1,17 @@
+-- Runs ONCE, on a fresh data volume, as the `postgres` superuser, connected to `llame`.
+--
+-- Creates the role the application connects as. It is deliberately:
+--   - NOT a superuser and NOT BYPASSRLS (either would bypass Row-Level Security), and
+--   - the OWNER of the database and the `public` schema.
+--
+-- Because migrations run as `app`, every table is owned by `app`; combined with
+-- `FORCE ROW LEVEL SECURITY` (migration 0004) this means RLS is enforced against the
+-- app role itself — the worst case for a single-role self-hosted deployment. Dev thus
+-- exercises the exact isolation guarantee production relies on (#53).
+--
+-- Dev-only credentials; do not reuse anywhere real.
+CREATE ROLE app WITH LOGIN PASSWORD 'app' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
+
+ALTER DATABASE llame OWNER TO app;
+ALTER SCHEMA public OWNER TO app;
+GRANT ALL ON SCHEMA public TO app;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db:migrate": "pnpm --filter api db:migrate",
     "db:generate": "pnpm --filter api db:generate",
     "db:studio": "pnpm --filter api db:studio",
-    "db:psql": "docker compose exec postgres psql -U postgres -d llame"
+    "db:psql": "docker compose exec -e PGPASSWORD=app postgres psql -U app -d llame"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,15 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "db:up": "docker compose up -d",
+    "db:down": "docker compose down",
+    "db:reset": "docker compose down -v && docker compose up -d",
+    "db:logs": "docker compose logs -f postgres",
+    "db:migrate": "pnpm --filter api db:migrate",
+    "db:generate": "pnpm --filter api db:generate",
+    "db:studio": "pnpm --filter api db:studio",
+    "db:psql": "docker compose exec postgres psql -U postgres -d llame"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",


### PR DESCRIPTION
## Summary

Implements **#53** — the v0.1 persistence foundation in `apps/api`: a multi-tenant, sender-attributed `chats` + `messages` schema (AI SDK v5 message shape), a deterministic cache-aware `ContextBuilder`, and per-request Row-Level Security so tenant isolation is enforced **in the database**, not just app code.

## What's included

- **Schema + migration** (`chats`, `messages`): `role` + `parts` (jsonb) AI SDK v5 shape; nullable `sender_user_id` for sender attribution; tenant boundary on `chats.owner_user_id`; required indexes. `owner_user_id`/`sender_user_id` are `text` to match the NextAuth `users.id`.
- **Row-Level Security, `ENABLE` + `FORCE`** on both tables. `FORCE` is load-bearing: without it a self-hosted deployment running the app on the table-owner role would silently bypass RLS.
- **`TenantDbService.runAs(userId, fn)`** — wraps each unit of work in a transaction that sets `app.current_user_id` (`set_config(..., true)`), so RLS is actually engaged per request. `ChatsService` is routed through it.
- **Deterministic, cache-aware `ContextBuilder`** — stable system prefix (byte-identical across turns), oldest→newest history, sender attribution when >1 sender, hard message cap.
- **Owner-scoped repositories** (defense-in-depth) on top of RLS.
- **Local dev DB**: root `compose.yaml` + `db:*` scripts that provision a non-superuser `app` role owning the schema, so dev exercises RLS/FORCE exactly as production. `apps/api/scripts/rls-test.sh` re-proves isolation against a throwaway Postgres in CI.

## Multi-tenant isolation — proven, not asserted

`scripts/rls-test.sh` stands up Postgres, creates a **non-superuser role that owns the schema** (the worst case for single-role self-hosting), applies migrations as that role, and runs the integration suite as it. 7/7 green, including cross-tenant reads returning **zero rows** both at the SQL layer and end-to-end through `ChatsService`, plus an assertion that `relforcerowsecurity = true` on both tables.

## Run it locally

```bash
cp apps/api/.env.example apps/api/.env.local
pnpm db:up && pnpm db:migrate
pnpm --filter api test            # unit; integration auto-skips without a DB
bash apps/api/scripts/rls-test.sh # full RLS proof on a throwaway Postgres
```

## Out of scope / follow-ups

- **Request auth** — identity currently comes from handler inputs; wiring it from a verified session/guard (and only then exposing these endpoints) is the next dependency.
- **`apps/web` cutover** — web still uses its own PoC schema; migration 0004 `DROP`s those tables, so the two can't share a DB until web is migrated.
- Model integration + streaming loop (#54/#55); event-sourcing, compaction (#57), `chat_participants`, `orgId`, partitioning — all deliberately deferred per the spec.

Closes #53.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #53: multi-tenant `chats` + `messages` with per-request RLS; this update finalizes deterministic ordering, visibility enum, tighter owner scoping, safer endpoints, and docs/tests.

- **Refactors**
  - Use `messages.seq` (bigint identity) for history order; repos and `ContextBuilder` sort by `seq` and cap after sorting.
  - Replace `chats.visibility` varchar with `chat_visibility` enum; declare `sender_user_id` FK as `onDelete: set null`; add `messages_chat_seq_idx`. Applied in migration `0005`.
  - Owner-scoped reads: `MessagesRepository.findByChatId` joins to `chats.owner_user_id` (defense-in-depth on top of RLS).
  - Controller: `GET /chats/:id` reads `ownerUserId` via query and returns 404 on miss; `PUT /chats/:id/title`; `GET /chats/owner/:ownerUserId`. Security note retained (client-supplied owner until auth wiring).
  - Tests/docs/tooling: stronger repo/tenant-db specs, RLS suite pool `max:2`, `scripts/rls-test.sh` fails fast on readiness, RLS/dev DB docs in `apps/api/AGENTS.md`.

- **Migration**
  - Copy env and run: `cp apps/api/.env.example apps/api/.env.local && pnpm db:up && pnpm db:migrate`.
  - `0004` drops the PoC tables; `0005` adds `chat_visibility` and `messages.seq` (additive). `apps/web` is not yet cut over to this schema.

<sup>Written for commit 49a6218154d8d77e792153974dad8048f40f587f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local Postgres setup and database commands for starting, stopping, resetting, and inspecting the dev database.
  * Updated chat storage and access so chats and messages are tied to an owner and protected by stricter isolation.

* **Bug Fixes**
  * Improved chat/message handling to prevent cross-tenant data leakage.
  * Messages now preserve full content, including richer message parts and attachments.

* **Documentation**
  * Added setup instructions for running the local database and applying migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->