### PR TITLE
fix(api): strip password hash from user responses (#64)

### DIFF
--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -18,6 +18,24 @@ describe('toPublicUser', () => {
     expect(pub.id).toBe('u1');
     expect(pub.email).toBe('alice@example.com');
   });
+
+  it('allowlists — an unknown/future secret column is NOT forwarded (fail closed)', () => {
+    const withFutureSecrets = {
+      ...userWithSecret,
+      totpSecret: 'TOTP_SECRET',
+      apiKey: 'API_KEY',
+    } as unknown as User;
+    const pub = toPublicUser(withFutureSecrets);
+    expect(Object.keys(pub).sort()).toEqual([
+      'email',
+      'emailVerified',
+      'id',
+      'image',
+      'name',
+    ]);
+    expect(JSON.stringify(pub)).not.toContain('TOTP_SECRET');
+    expect(JSON.stringify(pub)).not.toContain('API_KEY');
+  });
 });
 
 describe('UsersController — never leaks the password hash', () => {

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -1,0 +1,49 @@
+import { UsersController } from './users.controller';
+import { UsersService, toPublicUser } from './users.service';
+import type { User } from '../db/schema';
+
+const userWithSecret: User = {
+  id: 'u1',
+  name: 'Alice',
+  email: 'alice@example.com',
+  emailVerified: null,
+  image: null,
+  password: '$2b$10$SECRETHASH',
+};
+
+describe('toPublicUser', () => {
+  it('strips the password field', () => {
+    const pub = toPublicUser(userWithSecret);
+    expect(pub).not.toHaveProperty('password');
+    expect(pub.id).toBe('u1');
+    expect(pub.email).toBe('alice@example.com');
+  });
+});
+
+describe('UsersController — never leaks the password hash', () => {
+  const service = {
+    getUserById: jest.fn().mockResolvedValue(userWithSecret),
+    getUserByEmail: jest.fn().mockResolvedValue(userWithSecret),
+    createUser: jest.fn().mockResolvedValue(userWithSecret),
+  } as unknown as UsersService;
+  const controller = new UsersController(service);
+
+  it('getUserById omits password', async () => {
+    const res = await controller.getUserById('u1');
+    expect(res).toBeDefined();
+    expect(res).not.toHaveProperty('password');
+    expect(JSON.stringify(res)).not.toContain('SECRETHASH');
+  });
+
+  it('getUserByEmail omits password', async () => {
+    const res = await controller.getUserByEmail('alice@example.com');
+    expect(res).not.toHaveProperty('password');
+    expect(JSON.stringify(res)).not.toContain('SECRETHASH');
+  });
+
+  it('createUser omits password', async () => {
+    const res = await controller.createUser({ email: 'alice@example.com' });
+    expect(res).not.toHaveProperty('password');
+    expect(JSON.stringify(res)).not.toContain('SECRETHASH');
+  });
+});

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Param, Post, Body } from '@nestjs/common';
 import { UsersService, toPublicUser, type PublicUser } from './users.service';
 
-// SECURITY: every user returned over HTTP goes through `toPublicUser`, so the
-// `password` hash (and any future secret fields) never leaves the API. These
-// endpoints are not yet authenticated/authorization-scoped — that lands with #60.
+// SECURITY: every user returned over HTTP is projected through `toPublicUser`, which
+// ALLOWLISTS safe fields — so the `password` hash and any future secret column are
+// never serialized (fail closed). These endpoints are not yet authenticated /
+// authorization-scoped — that lands with #60.
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,21 +1,25 @@
 import { Controller, Get, Param, Post, Body } from '@nestjs/common';
-import { UsersService } from './users.service';
-import { User } from '../db/schema';
+import { UsersService, toPublicUser, type PublicUser } from './users.service';
 
+// SECURITY: every user returned over HTTP goes through `toPublicUser`, so the
+// `password` hash (and any future secret fields) never leaves the API. These
+// endpoints are not yet authenticated/authorization-scoped — that lands with #60.
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get(':id')
-  async getUserById(@Param('id') id: string): Promise<User | undefined> {
-    return this.usersService.getUserById(id);
+  async getUserById(@Param('id') id: string): Promise<PublicUser | undefined> {
+    const user = await this.usersService.getUserById(id);
+    return user ? toPublicUser(user) : undefined;
   }
 
   @Get('email/:email')
   async getUserByEmail(
     @Param('email') email: string,
-  ): Promise<User | undefined> {
-    return this.usersService.getUserByEmail(email);
+  ): Promise<PublicUser | undefined> {
+    const user = await this.usersService.getUserByEmail(email);
+    return user ? toPublicUser(user) : undefined;
   }
 
   @Post()
@@ -27,7 +31,7 @@ export class UsersController {
       password?: string;
       image?: string;
     },
-  ): Promise<User> {
-    return this.usersService.createUser(userData);
+  ): Promise<PublicUser> {
+    return toPublicUser(await this.usersService.createUser(userData));
   }
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -4,14 +4,23 @@ import { eq } from 'drizzle-orm';
 import * as schema from '../db/schema';
 import { User, users } from '../db/schema';
 
-/** A user safe to return over HTTP — never includes secrets such as the password hash. */
-export type PublicUser = Omit<User, 'password'>;
+// Allowlist, not blocklist: PublicUser enumerates the fields safe to expose. A new
+// column on `users` (e.g. a 2FA secret, OAuth/refresh token, API key) is NOT returned
+// over HTTP until someone explicitly adds it here — fail closed, never leak by default.
+export type PublicUser = Pick<
+  User,
+  'id' | 'name' | 'email' | 'emailVerified' | 'image'
+>;
 
-/** Strip secret fields before a user crosses the HTTP boundary. */
+/** Project a user to the fields safe to cross the HTTP boundary. */
 export function toPublicUser(user: User): PublicUser {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional rest-omit of `password`
-  const { password, ...pub } = user;
-  return pub;
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    emailVerified: user.emailVerified,
+    image: user.image,
+  };
 }
 
 // NOTE: the methods below return the FULL `User` (incl. `password`) for INTERNAL use

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -4,6 +4,19 @@ import { eq } from 'drizzle-orm';
 import * as schema from '../db/schema';
 import { User, users } from '../db/schema';
 
+/** A user safe to return over HTTP — never includes secrets such as the password hash. */
+export type PublicUser = Omit<User, 'password'>;
+
+/** Strip secret fields before a user crosses the HTTP boundary. */
+export function toPublicUser(user: User): PublicUser {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional rest-omit of `password`
+  const { password, ...pub } = user;
+  return pub;
+}
+
+// NOTE: the methods below return the FULL `User` (incl. `password`) for INTERNAL use
+// only — e.g. credential verification when auth lands (#60). Anything returning a user
+// over HTTP MUST map through `toPublicUser` first (see UsersController).
 @Injectable()
 export class UsersService {
   constructor(


### PR DESCRIPTION
## Summary

Fixes the unauthenticated **password-hash disclosure** (#64) found in the #60 security review. `GET /users/:id`, `GET /users/email/:email`, and `POST /users` returned the full `User` row — **including the bcrypt `password` hash** — to any caller.

## Fix

- Add `PublicUser = Omit<User, 'password'>` + `toPublicUser()` in `users.service.ts`.
- Apply it at the **controller boundary** — every user returned over HTTP is stripped of `password` (and any future secret fields).
- The **service keeps returning the full `User`** for internal use (credential verification when auth lands in #60), so this doesn't block that.
- Tests assert none of the three endpoints emit the hash.

## Verified
`apps/api` build + Jest (29 tests, incl. the new no-leak tests) + lint, all green.

## Deferred to #60
Authentication + authorization-scoping of these endpoints (they're still unauthenticated). This PR closes the *data-exposure* half independently and immediately.

Closes #64.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop exposing bcrypt password hashes in user API responses by projecting users to an allowlisted `PublicUser` (fail-closed). Applies to GET /users/:id, GET /users/email/:email, and POST /users; addresses #64 and aligns with upcoming auth in #60.

- **Bug Fixes**
  - Introduced allowlisted `PublicUser` + `toPublicUser()`; future secret columns are not serialized by default.
  - Mapped all controller responses to `toPublicUser()`; service still returns full `User` for internal use.
  - Added tests for all three endpoints and a guard test proving unknown secret fields are dropped.

<sup>Written for commit d9ee96f047386cc435bdd071b0e59787a83cac89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

