### PR TITLE
docs(spec): finalize §22.0 — direct-api, reliable IP, web auth-state model

### DIFF
--- a/.github/ISSUE_TEMPLATE/milestone-tracker.md
+++ b/.github/ISSUE_TEMPLATE/milestone-tracker.md
@@ -1,0 +1,94 @@
+---
+name: "📍 Milestone tracker (epic)"
+about: "Track a milestone/version as named tracks with a dependency chart (e.g. the v0.x epics). Group child issues into tracks, show the dependency graph, define the release gate."
+title: "tracking: vX.Y — <milestone name>"
+labels: []
+assignees: []
+---
+
+<!--
+HOW TO USE THIS TEMPLATE
+- This is for EPIC / tracking issues (a milestone or version), not individual work items.
+- Add the milestone's domain label(s) after creating (runs / identity / models / …).
+- Link each child issue as a GitHub sub-issue of this one (Issues sidebar → "Add sub-issue").
+- Keep child issues as the source of truth for scope/acceptance; this body is the map.
+- Delete every <!-- comment --> and replace <angle-bracket> placeholders before submitting.
+- The mermaid block renders on GitHub — keep it in sync when tracks/deps change.
+-->
+
+## <vX.Y>: <one-line milestone name>
+
+<!-- 2–3 sentences: the smallest useful version of this milestone, and what is explicitly deferred to later milestones. -->
+
+### Architecture overview
+
+<!-- Optional. A short paragraph on how the pieces fit, referencing child issues by #number and the relevant SPEC.md section(s). Remove if not useful. -->
+
+### Key design decisions
+
+<!-- Optional. The load-bearing choices for this milestone (one bullet each, with the "why"). Remove if not useful. -->
+
+- <decision — and why>
+- <decision — and why>
+
+## Tracks
+
+<!--
+Group child issues into a few named tracks by concern (e.g. "Persistence", "Model", "Auth", "Loop").
+Foundations first; the track that consumes them last. Mark shipped items [x], annotate cross-issue deps inline.
+Use one ### per track. An emoji prefix is optional but makes the rendered tracker scannable.
+-->
+
+### <emoji> <Track A name> — <one-line purpose>
+
+- [ ] #XX — <child issue title> _(requires #YY)_
+- [ ] #XX — <child issue title>
+
+### <emoji> <Track B name> — <one-line purpose>
+
+- [x] #XX — <child issue title> _(shipped)_
+- [ ] #XX — <child issue title> _(requires #XX)_
+
+### Track & dependency graph
+
+<!--
+Generalize this skeleton: one `subgraph` per track, intra-track edges inside it,
+cross-track dependency edges below. Tag nodes done/todo via classDef so status is visible.
+Edge direction = "A enables B" (blocker → blocked).
+-->
+
+```mermaid
+flowchart TD
+    subgraph trackA["Track A"]
+        A1["#XX short label"]
+    end
+
+    subgraph trackB["Track B"]
+        B1["#XX short label"]
+        B2["#XX short label"]
+        B1 --> B2
+    end
+
+    %% cross-track edges (blocker --> blocked)
+    A1 --> B1
+
+    classDef done fill:#d4f4dd,stroke:#22a060,color:#04331a;
+    classDef todo fill:#fff6d6,stroke:#caa106,color:#3a2f04;
+    class A1 done;
+    class B1,B2 todo;
+```
+
+### Build order
+
+<!-- The dependency-respecting sequence. "In parallel" where tracks are independent. -->
+
+1. **Foundations (parallel):** <tracks/issues with no blockers>
+2. **<next>:** <issues unblocked once step 1 lands>
+3. **Release gate:** <hardening / eval / test issues>
+
+### Success criteria
+
+<!-- Observable, testable conditions that close this milestone. The release gate, not a feature list. -->
+
+- <criterion>
+- <criterion>

--- a/SPEC.md
+++ b/SPEC.md
@@ -1941,27 +1941,51 @@ flowchart TD
 
 ## 22. Service Boundaries
 
-### 22.0 Client/server boundary & API surface (canonical)
+### 22.0 Client/server boundary, auth & deployment (canonical)
 
 **`apps/api` (NestJS) is the sole owner of the database** — schema, migrations, all DB access, authentication, RLS, and domain logic. The database is a private implementation detail of `apps/api`; no other process connects to it. It exposes two **independently-versioned** HTTP surfaces:
 
-- **`/auth/v1/*`** — authentication & session management (its own version line — different security posture, rate limits, and unauthenticated entry points).
+- **`/auth/v1/*`** — authentication & session management (own version line — different security posture, rate limits, unauthenticated entry points).
 - **`/api/v1/*`** — domain resources (chats, messages, models, …), each requiring a valid session.
 
-**All other apps are thin clients** of this API. `apps/web` (Next.js) is a **BFF**: no database connection, no ORM, no auth adapter — it renders UI and proxies to `apps/api`, relaying the session. A future `apps/mobile` is another client of the same API. This completes the "DB out of the web app" migration; the web app holds no schema.
+**Clients are thin and call the API directly.** `apps/web` (Next.js) is a UI/SPA — no database, ORM, or auth adapter, and **not** a request proxy/BFF: the browser calls `apps/api` directly at a configurable **`API_URL`**. A future `apps/mobile` is another direct client of the same API. This completes the "DB out of the web app" migration.
 
-**Authentication** uses revocable, **server-side sessions** with an **opaque token** (hashed at rest), per OWASP Session Management — not a stateless JWT (which cannot be revoked before expiry). Transport: an `HttpOnly; Secure; SameSite` cookie for web (set by the API), `Authorization: Bearer` for native clients; both resolve to the same `hash(token) → sessions` lookup (one session = one transport). Sessions are modeled as a resource:
+#### Transport, client IP & deployment
+
+- **Default — 3 services (`web` · `api` · `postgres`):** the browser hits api directly (`API_URL=https://api.<host>`). Because api terminates the connection it reads the **real client IP from its own socket** — reliable, enabling IP/subnet hardening (enterprise) and accurate rate-limiting, with **no proxy**.
+- **Optional reverse proxy** (single-host / same-origin): set `API_URL=/api` and front with a proxy; api sets `TRUST_PROXY=true` and reads `X-Forwarded-For` from that trusted hop only. We do **not** use Next.js `rewrites()` as the gateway — it does not reliably set `X-Forwarded-For` (double-proxying / header overwrites).
+- api's client-IP source: **socket peer by default; trusted `X-Forwarded-For` only when `TRUST_PROXY` is set** — reliable in both modes.
+- Chat streaming uses **SSE** (proxies cleanly; WebSockets do not).
+
+#### Sessions & cookies
+
+Revocable **server-side sessions** with an **opaque token** (`crypto.randomBytes(32)`, base64url), **hashed at rest** (SHA-256) — per OWASP Session Management, not a stateless JWT (can't be revoked). Transport: an `HttpOnly; Secure; SameSite=Lax` cookie for web (set by api), `Authorization: Bearer` for native clients; both resolve to the same `hash(token) → sessions` lookup.
+
+- **Cookie scope:** api runs as a **same-site subdomain** (`api.<host>`) with the cookie at `Domain=.<host>`, so it is sent to api *and* readable by web's middleware. CORS allows the web origin with credentials; an `Origin` allowlist + `SameSite=Lax` cover CSRF — **no CSRF token needed**. (A fully different api domain would require `SameSite=None` + a CSRF token; not the default.)
+- Sessions are revoked by row deletion (logout / sign-out-everywhere / breach) and **rotated** on privilege/credential change (session-fixation defense).
+
+`/auth/v1` models sessions as a resource:
 
 - `POST /auth/v1/login` (a verb — login carries credential/MFA/intermediate states that don't fit resource-create), `POST /auth/v1/register`, `GET /auth/v1/me`.
 - `GET /auth/v1/sessions` (list, with device metadata), `GET`/`DELETE /auth/v1/sessions/current`, `DELETE /auth/v1/sessions/{id}`, `DELETE /auth/v1/sessions` (revoke all *others*; `?scope=all` includes the caller's).
 
-Sessions are revoked by deletion (logout / sign-out-everywhere / breach) and rotated on privilege/credential change (session-fixation defense). This surface is grounded in real-world practice — Supabase (`/auth/v1` + a separate data API), Ory Kratos, Okta — and the OWASP cheat sheets.
+Grounded in real-world practice — Supabase (`/auth/v1` + a separate data API), Ory Kratos, Okta — and the OWASP cheat sheets.
 
-> Supersedes the earlier NextAuth-JWT-in-`apps/web` approach: the Credentials provider forces JWT (non-revocable), so the session layer moves into `apps/api` as above.
+#### How `apps/web` knows the auth state (layered)
+
+`apps/web` never reads the session (it's `HttpOnly`) — it asks api:
+
+1. **`middleware.ts` — optimistic presence check:** is the cookie present? if not, redirect to `/login` **before render**. No api call; fast. Requires the cookie to be readable by web (`Domain=.<host>`, above). Not the security boundary.
+2. **api guard — authoritative:** validates the session on every `/auth/v1`·`/api/v1` request (the real gate). `userId` comes only from the validated session, never from client input.
+3. **Client `401` interceptor:** any `401` → clear the cached user + redirect to `/login` — catches expiry/revocation mid-session on the next request (no polling).
+
+`GET /auth/v1/me` is the source of truth for rendered auth state (via TanStack Query). Optionally, `middleware.ts` may call `/auth/v1/me` for authoritative pre-render gating of protected routes, at the cost of one hop per navigation.
+
+> Supersedes the earlier NextAuth-JWT-in-`apps/web` approach: the Credentials provider forces JWT (non-revocable), so auth + sessions move into `apps/api`.
 
 ### 22.1 Web App
 
-A **thin BFF client** of `apps/api` (§22.0) — no database, ORM, or auth adapter; all data flows through the API. Responsibilities:
+A **thin client** of `apps/api` (§22.0) — a UI/SPA with no database, ORM, or auth adapter; it calls the API directly at `API_URL`. Responsibilities:
 
 - Chat UI.
 - Project UI.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1950,6 +1950,13 @@ flowchart TD
 
 **Clients are thin and call the API directly.** `apps/web` (Next.js) is a UI/SPA — no database, ORM, or auth adapter, and **not** a request proxy/BFF: the browser calls `apps/api` directly at a configurable **`API_URL`**. A future `apps/mobile` is another direct client of the same API. This completes the "DB out of the web app" migration.
 
+#### API contract (code-first OpenAPI)
+
+The API is **code-first OpenAPI**: every endpoint takes a typed request **DTO** validated by a global `ValidationPipe` (`whitelist + forbidNonWhitelisted` — unknown/invalid input rejected, fail-closed), and `@nestjs/swagger` derives a single **`openapi.json`** from those DTOs and explicit response types (e.g. `PublicUser` — never ad-hoc objects, mirroring the `toPublicUser` egress allowlist). The emitted spec — not a hand-written contract — is the **durable, authoritative description** of the surface; thin clients (`apps/web`, a future `apps/mobile`) are typed/generated **off it**, so contract drift surfaces as a build/type error rather than a runtime fault. Input validation (ingress allowlist) and `toPublicUser`-style response projection (egress allowlist) are the same fail-closed discipline at both ends of the boundary.
+
+- **v0.1:** emit `openapi.json`; type `apps/web`'s API client against it (e.g. `openapi-typescript`). The SSE stream endpoint is documented but hand-written — OpenAPI and most codegen model streaming poorly.
+- **Deferred (post-v0.1):** a full generated client/SDK, and any non-TS (mobile) client — added once the surface is stable and a real second consumer exists. The spec is the durable asset; generated clients are disposable.
+
 #### Transport, client IP & deployment
 
 - **Default — 3 services (`web` · `api` · `postgres`):** the browser hits api directly (`API_URL=https://api.<host>`). Because api terminates the connection it reads the **real client IP from its own socket** — reliable, enabling IP/subnet hardening (enterprise) and accurate rate-limiting, with **no proxy**.

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -45,6 +45,7 @@ Migrations run as a **non-superuser `app` role that owns the schema** (provision
 
 - One NestJS module per feature (controller / service / module); wire via DI and register in `app.module.ts`.
 - Schema lives in `src/db/schema`; change it, then `db:generate`. Don't hand-edit generated migration SQL or `meta/_journal.json` — the sole exception (`0004`) is documented in Gotchas.
+- **API contract — code-first OpenAPI** (decision + rationale: SPEC §22.0; established by #60). Every `/auth/v1`·`/api/v1` endpoint takes a class-validator **DTO** behind the global `ValidationPipe` and returns an **explicit response type** (never an ad-hoc object — mirror the `toPublicUser` egress allowlist), so `@nestjs/swagger` can emit a complete `openapi.json`. Add a DTO + response type with every new endpoint. Client/SDK codegen is **deferred** (post-v0.1) — don't hand-write or generate an API client yet; the spec is the source of truth.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Finalizes the auth/topology decisions in **§22.0** (and fixes §22.1), replacing the earlier BFF/cookie-relay framing:

- **Direct API access.** `apps/web` (and future `apps/mobile`) call `apps/api` directly at a configurable **`API_URL`** — web is a thin UI/SPA, **not** a proxy/BFF.
- **Reliable client IP.** api terminates the connection → reads the real IP from its socket (enables enterprise **IP/subnet hardening** + accurate rate-limiting). `TRUST_PROXY` + `X-Forwarded-For` only for an optional reverse proxy. **No Next.js `rewrites()` gateway** (it doesn't reliably set XFF).
- **3-service default** (`web` · `api` · `postgres`); optional proxy is a config flip, not a required service.
- **Cookie:** `HttpOnly; Secure; SameSite=Lax`, `Domain=.<host>` (api on a same-site subdomain) → readable by web middleware + sent to api; CORS-with-credentials + `Origin` allowlist; no CSRF token in the default deploy.
- **Web auth-state model (layered):** `middleware.ts` optimistic presence-check (pre-render redirect) → api guard authoritative → client `401` interceptor (catches revocation/expiry); `/auth/v1/me` is the source of truth.
- Chat streaming over **SSE**.

Drives the realigned **#60** (api auth backend) and **#63** (web thin client) specs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes §22.0 of the auth/topology spec: clients call the API directly, the API reads reliable client IPs, and the web uses a layered auth-state model. Adds a code-first OpenAPI contract and a milestone-tracker issue template; keeps the default `web·api·postgres` deploy and SSE for chat.

- **Refactors**
  - Replace BFF/proxy with direct API calls: `apps/web` (and future mobile) call `apps/api` via `API_URL`.
  - Define client IP source: socket by default; enable trusted `X-Forwarded-For` only with `TRUST_PROXY`; avoid Next.js `rewrites()` as a gateway.
  - Clarify sessions/cookies: server-side opaque tokens (hashed), `HttpOnly; Secure; SameSite=Lax`, `Domain=.<host>`, CORS with credentials; no CSRF token by default.
  - Set web auth-state flow: middleware presence check → API guard authoritative → client 401 interceptor; `/auth/v1/me` is the source of truth.
  - Default 3-service deploy (`web`, `api`, `postgres`); reverse proxy optional; chat streaming via SSE.
  - Establish code-first OpenAPI: typed DTOs + global validation, explicit response types; `@nestjs/swagger` emits `openapi.json`; clients type against the spec; SDK codegen deferred.

- **New Features**
  - Add `.github` milestone-tracker issue template with tracks and a Mermaid dependency graph.

<sup>Written for commit be0506acd541ca2dec0be6b9d3645fa6e006c7be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the app’s client/server boundary and deployment model.
  * Updated authentication and session guidance to reflect revocable, server-validated sessions.
  * Refined networking and security behavior, including proxy trust, client IP handling, and streaming support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->