### PR TITLE
feat(api): single-model streaming Q&A loop — POST /api/v1/chats/:id/messages (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 _Reverse-chronological record of shipped work — features, fixes, and chores. Newest first._
 
+# 2026-06-30
+
+- Added the `apps/api` single-model streaming chat loop (#55): guarded `POST /api/v1/chats/:id/messages`, server-authoritative context, idempotent client message ids, AI SDK UI-message SSE streaming, assistant persistence with usage, and abort/cross-tenant/fail-fast e2e coverage.
+
 # 2026-06-29
 
 - Shipped the v0.1 multi-tenant chat foundation (#53, #59): `chats`/`messages` schema (AI SDK v5 `role`+`parts`, sender-attributed) with a monotonic `seq` ordering key, a `chat_visibility` enum, and a deterministic, cache-aware `ContextBuilder`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,6 @@ flowchart LR
 The smallest useful version: single-user, single-model **streaming** Q&A — no worker, no tools, no supervisor.
 
 - Minimal model integration: one provider, user-supplied key, behind a `ModelClient` interface. (SPEC §14) — #54
-- Single-model streaming loop, replacing the `langgraph-supervisor` chat path. (SPEC §9) — #55
 - Per-run budgets + cost/token/cache telemetry. (SPEC §29) — #56
 - Conversation context compaction for long chats. — #57
 - Minimal eval set: happy path, prompt injection, context overflow, budget. — #58

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -526,9 +526,6 @@
           },
           "409": {
             "description": "Message turn already completed"
-          },
-          "502": {
-            "description": "Model stream failed"
           }
         },
         "security": [
@@ -800,6 +797,8 @@
             "format": "uuid"
           },
           "parts": {
+            "minItems": 1,
+            "maxItems": 50,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CreateTextMessagePartDto"

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -476,6 +476,73 @@
           "chats"
         ]
       }
+    },
+    "/api/v1/chats/{id}/messages": {
+      "post": {
+        "operationId": "ChatsController_createMessage",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMessageDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "AI SDK v5 UI-message stream (SSE)",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed chat id or invalid message body"
+          },
+          "401": {
+            "description": ""
+          },
+          "402": {
+            "description": "No model credential configured for the user"
+          },
+          "404": {
+            "description": "Chat not found or not owned"
+          },
+          "409": {
+            "description": "Message turn already completed"
+          },
+          "502": {
+            "description": "Model stream failed"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "chats"
+        ]
+      }
     }
   },
   "info": {
@@ -704,6 +771,56 @@
             "maxLength": 200
           }
         }
+      },
+      "CreateTextMessagePartDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 20000
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ]
+      },
+      "CreateMessageBodyDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateTextMessagePartDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "parts"
+        ]
+      },
+      "CreateMessageDto": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/CreateMessageBodyDto"
+          }
+        },
+        "required": [
+          "message"
+        ]
       },
       "UpdateChatDto": {
         "type": "object",

--- a/apps/api/src/chats/chat-loop.service.ts
+++ b/apps/api/src/chats/chat-loop.service.ts
@@ -3,6 +3,7 @@ import {
   HttpException,
   HttpStatus,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import type { LanguageModelUsage, ModelMessage as AiModelMessage } from 'ai';
@@ -17,6 +18,7 @@ import { ModelsService } from '../models/models.service';
 import { ChatsRepository, MessagesRepository } from './chats-repository';
 import {
   buildContext,
+  DEFAULT_MAX_MESSAGES,
   type MessagePart,
   type StoredMessage,
 } from './context-builder';
@@ -31,6 +33,8 @@ export type ChatMessageInput = {
 
 @Injectable()
 export class ChatLoopService {
+  private readonly logger = new Logger(ChatLoopService.name);
+
   constructor(
     private readonly tenantDb: TenantDbService,
     private readonly models: ModelsService,
@@ -45,30 +49,27 @@ export class ChatLoopService {
     const credential = await this.resolveCredential(input.userId);
     const client = this.models.createOpenAIClient(credential);
 
-    await this.assertPreconditions(
-      input.chatId,
-      input.userId,
-      input.message.id,
-    );
-
-    const { context } = await this.persistUserAndBuildContext(input);
+    const context = await this.persistUserAndBuildContext(input);
 
     return client.streamText({
       messages: context,
       abortSignal: input.abortSignal,
       onFinish: async ({ text, usage, finishReason }) => {
-        if (input.abortSignal?.aborted) {
-          return;
+        try {
+          await this.persistAssistantMessage({
+            chatId: input.chatId,
+            userId: input.userId,
+            inReplyTo: input.message.id,
+            text,
+            usage,
+            finishReason,
+          });
+        } catch (error) {
+          this.logger.error(
+            `Failed to persist assistant message for chat ${input.chatId}`,
+            error instanceof Error ? error.stack : String(error),
+          );
         }
-
-        await this.persistAssistantMessage({
-          chatId: input.chatId,
-          userId: input.userId,
-          inReplyTo: input.message.id,
-          text,
-          usage,
-          finishReason,
-        });
       },
     });
   }
@@ -92,52 +93,11 @@ export class ChatLoopService {
     }
   }
 
-  private async assertPreconditions(
-    chatId: string,
-    userId: string,
-    userMessageId: string,
-  ): Promise<void> {
-    await this.tenantDb.runAs(userId, async (tx) => {
-      const chatsRepo = new ChatsRepository(tx);
-      const messagesRepo = new MessagesRepository(tx);
-
-      const chat = await chatsRepo.findById(chatId, userId);
-      if (!chat) {
-        throw new NotFoundException(`Chat ${chatId} not found`);
-      }
-
-      const turn = await messagesRepo.findTurnState(
-        chatId,
-        userId,
-        userMessageId,
-      );
-      if (turn.assistantMessage) {
-        throw new ConflictException('Message turn already completed');
-      }
-    });
-  }
-
   private async persistUserAndBuildContext(input: {
     chatId: string;
     userId: string;
     message: ChatMessageInput;
-  }): Promise<{ userMessage: Message; context: AiModelMessage[] }> {
-    try {
-      return await this.persistUserAndBuildContextOnce(input);
-    } catch (error) {
-      if (!isUniqueViolation(error)) {
-        throw error;
-      }
-
-      return this.persistUserAndBuildContextOnce(input);
-    }
-  }
-
-  private async persistUserAndBuildContextOnce(input: {
-    chatId: string;
-    userId: string;
-    message: ChatMessageInput;
-  }): Promise<{ userMessage: Message; context: AiModelMessage[] }> {
+  }): Promise<AiModelMessage[]> {
     return this.tenantDb.runAs(input.userId, async (tx) => {
       const chatsRepo = new ChatsRepository(tx);
       const messagesRepo = new MessagesRepository(tx);
@@ -156,26 +116,45 @@ export class ChatLoopService {
         throw new ConflictException('Message turn already completed');
       }
 
-      const userMessage =
-        turn.userMessage ??
-        (await messagesRepo.create({
+      let userMessage: Message | undefined = turn.userMessage;
+
+      if (!userMessage) {
+        userMessage = await messagesRepo.createUserMessageIfAbsent({
           id: input.message.id,
           chatId: input.chatId,
-          role: 'user',
           senderUserId: input.userId,
           parts: input.message.parts,
-        }));
+        });
+      }
+
+      if (!userMessage) {
+        const retryTurn = await messagesRepo.findTurnState(
+          input.chatId,
+          input.userId,
+          input.message.id,
+        );
+        if (retryTurn.assistantMessage) {
+          throw new ConflictException('Message turn already completed');
+        }
+
+        userMessage = retryTurn.userMessage;
+      }
+
+      if (!userMessage) {
+        throw new ConflictException('Message id already exists');
+      }
 
       const history = await messagesRepo.findByChatId(
         input.chatId,
         input.userId,
-        { maxSeq: userMessage.seq },
+        { maxSeq: userMessage.seq, limit: DEFAULT_MAX_MESSAGES },
       );
       const context = buildContext(history as StoredMessage[], {
         systemPrompt: CHAT_SYSTEM_PROMPT,
+        maxMessages: DEFAULT_MAX_MESSAGES,
       }) as AiModelMessage[];
 
-      return { userMessage, context };
+      return context;
     });
   }
 
@@ -199,10 +178,8 @@ export class ChatLoopService {
         return;
       }
 
-      await messagesRepo.create({
+      await messagesRepo.createAssistantReplyIfAbsent({
         chatId: input.chatId,
-        role: 'assistant',
-        senderUserId: null,
         parts: [{ type: 'text', text: input.text }],
         usage: { ...input.usage, finishReason: input.finishReason },
         inReplyTo: input.inReplyTo,
@@ -214,16 +191,5 @@ export class ChatLoopService {
 function isMissingCredential(
   error: unknown,
 ): error is MissingModelCredentialError {
-  return (
-    error instanceof MissingModelCredentialError ||
-    (isRecord(error) && error.code === 'missing_model_credential')
-  );
-}
-
-function isUniqueViolation(error: unknown): boolean {
-  return isRecord(error) && error.code === '23505';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return error instanceof MissingModelCredentialError;
 }

--- a/apps/api/src/chats/chat-loop.service.ts
+++ b/apps/api/src/chats/chat-loop.service.ts
@@ -1,0 +1,229 @@
+import {
+  ConflictException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { LanguageModelUsage, ModelMessage as AiModelMessage } from 'ai';
+
+import { TenantDbService } from '../db/tenant-db.service';
+import { type Message } from '../db/schema';
+import {
+  MissingModelCredentialError,
+  type ModelClient,
+} from '../models/model-client';
+import { ModelsService } from '../models/models.service';
+import { ChatsRepository, MessagesRepository } from './chats-repository';
+import {
+  buildContext,
+  type MessagePart,
+  type StoredMessage,
+} from './context-builder';
+
+export const CHAT_SYSTEM_PROMPT =
+  'You are llame, an answer-only assistant. Answer the latest user message directly. Do not claim to use tools or take external actions.';
+
+export type ChatMessageInput = {
+  id: string;
+  parts: MessagePart[];
+};
+
+@Injectable()
+export class ChatLoopService {
+  constructor(
+    private readonly tenantDb: TenantDbService,
+    private readonly models: ModelsService,
+  ) {}
+
+  async createMessageStream(input: {
+    chatId: string;
+    userId: string;
+    message: ChatMessageInput;
+    abortSignal?: AbortSignal;
+  }): Promise<ReturnType<ModelClient['streamText']>> {
+    const credential = await this.resolveCredential(input.userId);
+    const client = this.models.createOpenAIClient(credential);
+
+    await this.assertPreconditions(
+      input.chatId,
+      input.userId,
+      input.message.id,
+    );
+
+    const { context } = await this.persistUserAndBuildContext(input);
+
+    return client.streamText({
+      messages: context,
+      abortSignal: input.abortSignal,
+      onFinish: async ({ text, usage, finishReason }) => {
+        if (input.abortSignal?.aborted) {
+          return;
+        }
+
+        await this.persistAssistantMessage({
+          chatId: input.chatId,
+          userId: input.userId,
+          inReplyTo: input.message.id,
+          text,
+          usage,
+          finishReason,
+        });
+      },
+    });
+  }
+
+  private async resolveCredential(userId: string): Promise<string> {
+    try {
+      return await this.models.resolveModelCredential(userId);
+    } catch (error) {
+      if (isMissingCredential(error)) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.PAYMENT_REQUIRED,
+            error: 'Payment Required',
+            message: 'No model credential configured.',
+          },
+          HttpStatus.PAYMENT_REQUIRED,
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private async assertPreconditions(
+    chatId: string,
+    userId: string,
+    userMessageId: string,
+  ): Promise<void> {
+    await this.tenantDb.runAs(userId, async (tx) => {
+      const chatsRepo = new ChatsRepository(tx);
+      const messagesRepo = new MessagesRepository(tx);
+
+      const chat = await chatsRepo.findById(chatId, userId);
+      if (!chat) {
+        throw new NotFoundException(`Chat ${chatId} not found`);
+      }
+
+      const turn = await messagesRepo.findTurnState(
+        chatId,
+        userId,
+        userMessageId,
+      );
+      if (turn.assistantMessage) {
+        throw new ConflictException('Message turn already completed');
+      }
+    });
+  }
+
+  private async persistUserAndBuildContext(input: {
+    chatId: string;
+    userId: string;
+    message: ChatMessageInput;
+  }): Promise<{ userMessage: Message; context: AiModelMessage[] }> {
+    try {
+      return await this.persistUserAndBuildContextOnce(input);
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
+
+      return this.persistUserAndBuildContextOnce(input);
+    }
+  }
+
+  private async persistUserAndBuildContextOnce(input: {
+    chatId: string;
+    userId: string;
+    message: ChatMessageInput;
+  }): Promise<{ userMessage: Message; context: AiModelMessage[] }> {
+    return this.tenantDb.runAs(input.userId, async (tx) => {
+      const chatsRepo = new ChatsRepository(tx);
+      const messagesRepo = new MessagesRepository(tx);
+
+      const chat = await chatsRepo.findById(input.chatId, input.userId);
+      if (!chat) {
+        throw new NotFoundException(`Chat ${input.chatId} not found`);
+      }
+
+      const turn = await messagesRepo.findTurnState(
+        input.chatId,
+        input.userId,
+        input.message.id,
+      );
+      if (turn.assistantMessage) {
+        throw new ConflictException('Message turn already completed');
+      }
+
+      const userMessage =
+        turn.userMessage ??
+        (await messagesRepo.create({
+          id: input.message.id,
+          chatId: input.chatId,
+          role: 'user',
+          senderUserId: input.userId,
+          parts: input.message.parts,
+        }));
+
+      const history = await messagesRepo.findByChatId(
+        input.chatId,
+        input.userId,
+        { maxSeq: userMessage.seq },
+      );
+      const context = buildContext(history as StoredMessage[], {
+        systemPrompt: CHAT_SYSTEM_PROMPT,
+      }) as AiModelMessage[];
+
+      return { userMessage, context };
+    });
+  }
+
+  private async persistAssistantMessage(input: {
+    chatId: string;
+    userId: string;
+    inReplyTo: string;
+    text: string;
+    usage: LanguageModelUsage;
+    finishReason: string;
+  }): Promise<void> {
+    await this.tenantDb.runAs(input.userId, async (tx) => {
+      const messagesRepo = new MessagesRepository(tx);
+      const turn = await messagesRepo.findTurnState(
+        input.chatId,
+        input.userId,
+        input.inReplyTo,
+      );
+
+      if (turn.assistantMessage) {
+        return;
+      }
+
+      await messagesRepo.create({
+        chatId: input.chatId,
+        role: 'assistant',
+        senderUserId: null,
+        parts: [{ type: 'text', text: input.text }],
+        usage: { ...input.usage, finishReason: input.finishReason },
+        inReplyTo: input.inReplyTo,
+      });
+    });
+  }
+}
+
+function isMissingCredential(
+  error: unknown,
+): error is MissingModelCredentialError {
+  return (
+    error instanceof MissingModelCredentialError ||
+    (isRecord(error) && error.code === 'missing_model_credential')
+  );
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return isRecord(error) && error.code === '23505';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/api/src/chats/chat-loop.service.ts
+++ b/apps/api/src/chats/chat-loop.service.ts
@@ -1,19 +1,15 @@
 import {
   ConflictException,
-  HttpException,
-  HttpStatus,
   Injectable,
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { isDeepStrictEqual } from 'node:util';
 import type { LanguageModelUsage, ModelMessage as AiModelMessage } from 'ai';
 
 import { TenantDbService } from '../db/tenant-db.service';
 import { type Message } from '../db/schema';
-import {
-  MissingModelCredentialError,
-  type ModelClient,
-} from '../models/model-client';
+import { type ModelClient } from '../models/model-client';
 import { ModelsService } from '../models/models.service';
 import { ChatsRepository, MessagesRepository } from './chats-repository';
 import {
@@ -46,7 +42,9 @@ export class ChatLoopService {
     message: ChatMessageInput;
     abortSignal?: AbortSignal;
   }): Promise<ReturnType<ModelClient['streamText']>> {
-    const credential = await this.resolveCredential(input.userId);
+    // Throws MissingModelCredentialError (a domain error) when absent; the controller
+    // maps it to HTTP 402. The service stays HTTP-agnostic (it will move to a worker, §9.5).
+    const credential = await this.models.resolveModelCredential(input.userId);
     const client = this.models.createOpenAIClient(credential);
 
     const context = await this.persistUserAndBuildContext(input);
@@ -74,25 +72,6 @@ export class ChatLoopService {
     });
   }
 
-  private async resolveCredential(userId: string): Promise<string> {
-    try {
-      return await this.models.resolveModelCredential(userId);
-    } catch (error) {
-      if (isMissingCredential(error)) {
-        throw new HttpException(
-          {
-            statusCode: HttpStatus.PAYMENT_REQUIRED,
-            error: 'Payment Required',
-            message: 'No model credential configured.',
-          },
-          HttpStatus.PAYMENT_REQUIRED,
-        );
-      }
-
-      throw error;
-    }
-  }
-
   private async persistUserAndBuildContext(input: {
     chatId: string;
     userId: string;
@@ -114,6 +93,22 @@ export class ChatLoopService {
       );
       if (turn.assistantMessage) {
         throw new ConflictException('Message turn already completed');
+      }
+
+      // Idempotency key reuse with different content is a client error, not a retry.
+      // Normalize both sides to plain JSON first: the stored parts are plain (from jsonb)
+      // while input parts are class-transformer instances, so a raw deep-equal would
+      // always differ on the prototype.
+      if (
+        turn.userMessage &&
+        !isDeepStrictEqual(
+          normalizeJson(turn.userMessage.parts),
+          normalizeJson(input.message.parts),
+        )
+      ) {
+        throw new ConflictException(
+          'Message id already used with different content',
+        );
       }
 
       let userMessage: Message | undefined = turn.userMessage;
@@ -143,6 +138,9 @@ export class ChatLoopService {
       if (!userMessage) {
         throw new ConflictException('Message id already exists');
       }
+
+      // Mark chat activity so it sorts to the top of the chat list (findByOwner).
+      await chatsRepo.touch(input.chatId, input.userId);
 
       const history = await messagesRepo.findByChatId(
         input.chatId,
@@ -178,6 +176,12 @@ export class ChatLoopService {
         return;
       }
 
+      // The user turn must still exist (it was persisted before streaming). If it's gone
+      // — e.g. the chat was deleted mid-stream — skip rather than hit an in_reply_to FK error.
+      if (!turn.userMessage) {
+        return;
+      }
+
       await messagesRepo.createAssistantReplyIfAbsent({
         chatId: input.chatId,
         parts: [{ type: 'text', text: input.text }],
@@ -188,14 +192,7 @@ export class ChatLoopService {
   }
 }
 
-/**
- * Checks whether an error is a missing model credential error.
- *
- * @param error - The value to check
- * @returns `true` if `error` is a `MissingModelCredentialError`, `false` otherwise
- */
-function isMissingCredential(
-  error: unknown,
-): error is MissingModelCredentialError {
-  return error instanceof MissingModelCredentialError;
+/** Strip class prototypes / undefined so two structurally-equal shapes compare equal. */
+function normalizeJson(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value));
 }

--- a/apps/api/src/chats/chat-loop.service.ts
+++ b/apps/api/src/chats/chat-loop.service.ts
@@ -188,6 +188,12 @@ export class ChatLoopService {
   }
 }
 
+/**
+ * Checks whether an error is a missing model credential error.
+ *
+ * @param error - The value to check
+ * @returns `true` if `error` is a `MissingModelCredentialError`, `false` otherwise
+ */
 function isMissingCredential(
   error: unknown,
 ): error is MissingModelCredentialError {

--- a/apps/api/src/chats/chats-repository.spec.ts
+++ b/apps/api/src/chats/chats-repository.spec.ts
@@ -23,6 +23,7 @@ function makeMockDb() {
   const whereSpy = jest.fn();
   const valuesSpy = jest.fn();
   const setSpy = jest.fn();
+  const limitSpy = jest.fn();
   const terminal = {
     execute: jest.fn().mockResolvedValue([]),
     returning: jest.fn().mockResolvedValue([]),
@@ -30,8 +31,12 @@ function makeMockDb() {
 
   function chain(): Record<string, jest.Mock> {
     const obj: Record<string, jest.Mock> = {};
-    ['from', 'innerJoin', 'orderBy', 'limit'].forEach((m) => {
+    ['from', 'innerJoin', 'orderBy'].forEach((m) => {
       obj[m] = jest.fn(() => ({ ...obj, ...terminal }));
+    });
+    obj.limit = jest.fn((arg: unknown) => {
+      limitSpy(arg);
+      return { ...obj, ...terminal };
     });
     obj.where = jest.fn((arg: unknown) => {
       whereSpy(arg);
@@ -63,13 +68,14 @@ function makeMockDb() {
     whereSpy,
     valuesSpy,
     setSpy,
+    limitSpy,
   };
 }
 
 // Drizzle wraps bound values in Params; compile each captured where-condition to
 // SQL + params via the real dialect and assert the id is a bound parameter.
 const dialect = new PgDialect();
-function whereContains(whereSpy: jest.Mock, value: string): boolean {
+function whereContains(whereSpy: jest.Mock, value: string | number): boolean {
   return whereSpy.mock.calls.some((call: unknown[]) => {
     try {
       return dialect.sqlToQuery(call[0] as never).params.includes(value);
@@ -139,6 +145,18 @@ describe('MessagesRepository — owner-scoped + chat-scoped', () => {
       .catch(() => null);
     expect(whereContains(whereSpy, ownerUserId)).toBe(true);
     expect(whereContains(whereSpy, chatId)).toBe(true);
+  });
+
+  it('findByChatId applies the max seq boundary and requested history limit', async () => {
+    const { db, whereSpy, limitSpy } = makeMockDb();
+    await new MessagesRepository(db)
+      .findByChatId(chatId, ownerUserId, { maxSeq: 42, limit: 100 })
+      .catch(() => null);
+
+    expect(whereContains(whereSpy, ownerUserId)).toBe(true);
+    expect(whereContains(whereSpy, chatId)).toBe(true);
+    expect(whereContains(whereSpy, 42)).toBe(true);
+    expect(limitSpy).toHaveBeenCalledWith(100);
   });
 
   it('create inserts carrying chatId and senderUserId', async () => {

--- a/apps/api/src/chats/chats-repository.ts
+++ b/apps/api/src/chats/chats-repository.ts
@@ -113,7 +113,7 @@ export class MessagesRepository {
   async findByChatId(
     chatId: string,
     ownerUserId: string,
-    options?: { maxSeq?: number },
+    options?: { maxSeq?: number; limit?: number },
   ): Promise<Message[]> {
     const predicates = [
       eq(messages.chatId, chatId),
@@ -124,14 +124,21 @@ export class MessagesRepository {
       predicates.push(lte(messages.seq, options.maxSeq));
     }
 
-    const rows = await this.db
+    const query = this.db
       .select()
       .from(messages)
       .innerJoin(chats, eq(messages.chatId, chats.id))
-      .where(and(...predicates))
-      .orderBy(asc(messages.seq));
+      .where(and(...predicates));
 
-    return rows.map((r) => r.messages);
+    const rows =
+      options?.limit === undefined
+        ? await query.orderBy(asc(messages.seq))
+        : await query.orderBy(desc(messages.seq)).limit(options.limit);
+
+    const orderedRows =
+      options?.limit === undefined ? rows : [...rows].reverse();
+
+    return orderedRows.map((r) => r.messages);
   }
 
   /**
@@ -212,6 +219,52 @@ export class MessagesRepository {
         usage: input.usage,
         inReplyTo: input.inReplyTo ?? null,
       })
+      .returning();
+
+    return created;
+  }
+
+  async createUserMessageIfAbsent(input: {
+    id: string;
+    chatId: string;
+    senderUserId: string;
+    parts: unknown[];
+    attachments?: unknown[];
+  }): Promise<Message | undefined> {
+    const [created] = await this.db
+      .insert(messages)
+      .values({
+        id: input.id,
+        chatId: input.chatId,
+        role: 'user',
+        senderUserId: input.senderUserId,
+        parts: input.parts,
+        attachments: input.attachments ?? [],
+      })
+      .onConflictDoNothing({ target: messages.id })
+      .returning();
+
+    return created;
+  }
+
+  async createAssistantReplyIfAbsent(input: {
+    chatId: string;
+    parts: unknown[];
+    usage?: unknown;
+    inReplyTo: string;
+  }): Promise<Message | undefined> {
+    const [created] = await this.db
+      .insert(messages)
+      .values({
+        chatId: input.chatId,
+        role: 'assistant',
+        senderUserId: null,
+        parts: input.parts,
+        attachments: [],
+        usage: input.usage,
+        inReplyTo: input.inReplyTo,
+      })
+      .onConflictDoNothing({ target: messages.inReplyTo })
       .returning();
 
     return created;

--- a/apps/api/src/chats/chats-repository.ts
+++ b/apps/api/src/chats/chats-repository.ts
@@ -97,6 +97,17 @@ export class ChatsRepository {
 
     return updated;
   }
+
+  /**
+   * Bump a chat's updatedAt to mark recent activity (e.g. a new message turn), so
+   * findByOwner (ordered by updatedAt) floats active chats to the top. Owner-scoped.
+   */
+  async touch(chatId: string, ownerUserId: string): Promise<void> {
+    await this.db
+      .update(chats)
+      .set({ updatedAt: new Date() })
+      .where(and(eq(chats.id, chatId), eq(chats.ownerUserId, ownerUserId)));
+  }
 }
 
 export class MessagesRepository {

--- a/apps/api/src/chats/chats-repository.ts
+++ b/apps/api/src/chats/chats-repository.ts
@@ -8,7 +8,7 @@
  * It is typed loosely here so it can be injected by NestJS DI or mocked in tests.
  */
 
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, lte } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../db/schema';
 import {
@@ -110,17 +110,76 @@ export class MessagesRepository {
    * by `ownerUserId`, so a caller that forgets the RLS-scoped transaction still
    * cannot read another tenant's messages. RLS remains the primary guarantee.
    */
-  async findByChatId(chatId: string, ownerUserId: string): Promise<Message[]> {
+  async findByChatId(
+    chatId: string,
+    ownerUserId: string,
+    options?: { maxSeq?: number },
+  ): Promise<Message[]> {
+    const predicates = [
+      eq(messages.chatId, chatId),
+      eq(chats.ownerUserId, ownerUserId),
+    ];
+
+    if (options?.maxSeq !== undefined) {
+      predicates.push(lte(messages.seq, options.maxSeq));
+    }
+
     const rows = await this.db
       .select()
       .from(messages)
       .innerJoin(chats, eq(messages.chatId, chats.id))
-      .where(
-        and(eq(messages.chatId, chatId), eq(chats.ownerUserId, ownerUserId)),
-      )
+      .where(and(...predicates))
       .orderBy(asc(messages.seq));
 
     return rows.map((r) => r.messages);
+  }
+
+  /**
+   * Find a user turn and its assistant reply, scoped to one owned chat.
+   * Used for client-message-id idempotency before any new write or model call.
+   */
+  async findTurnState(
+    chatId: string,
+    ownerUserId: string,
+    userMessageId: string,
+  ): Promise<{
+    userMessage?: Message;
+    assistantMessage?: Message;
+  }> {
+    const [userMessage] = (
+      await this.db
+        .select()
+        .from(messages)
+        .innerJoin(chats, eq(messages.chatId, chats.id))
+        .where(
+          and(
+            eq(messages.id, userMessageId),
+            eq(messages.chatId, chatId),
+            eq(messages.role, 'user'),
+            eq(chats.ownerUserId, ownerUserId),
+          ),
+        )
+        .limit(1)
+    ).map((r) => r.messages);
+
+    const [assistantMessage] = (
+      await this.db
+        .select()
+        .from(messages)
+        .innerJoin(chats, eq(messages.chatId, chats.id))
+        .where(
+          and(
+            eq(messages.chatId, chatId),
+            eq(messages.role, 'assistant'),
+            eq(messages.inReplyTo, userMessageId),
+            eq(chats.ownerUserId, ownerUserId),
+          ),
+        )
+        .orderBy(asc(messages.seq))
+        .limit(1)
+    ).map((r) => r.messages);
+
+    return { userMessage, assistantMessage };
   }
 
   /**
@@ -132,20 +191,26 @@ export class MessagesRepository {
    * it would be a redundant round-trip; the RLS WITH CHECK is atomic.)
    */
   async create(input: {
+    id?: string;
     chatId: string;
     role: MessageRole;
     senderUserId?: string | null;
     parts: unknown[];
     attachments?: unknown[];
+    usage?: unknown;
+    inReplyTo?: string | null;
   }): Promise<Message> {
     const [created] = await this.db
       .insert(messages)
       .values({
+        ...(input.id !== undefined ? { id: input.id } : {}),
         chatId: input.chatId,
         role: input.role,
         senderUserId: input.senderUserId ?? null,
         parts: input.parts,
         attachments: input.attachments ?? [],
+        usage: input.usage,
+        inReplyTo: input.inReplyTo ?? null,
       })
       .returning();
 

--- a/apps/api/src/chats/chats.controller.spec.ts
+++ b/apps/api/src/chats/chats.controller.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 
 import { NotFoundException } from '@nestjs/common';
+import { EventEmitter } from 'node:events';
+import type { Request, Response as ExpressResponse } from 'express';
 import { ChatsController } from './chats.controller';
 import type { ChatLoopService } from './chat-loop.service';
 import type { ChatsService } from './chats.service';
@@ -16,6 +18,23 @@ const chat: Chat = {
 };
 
 describe('ChatsController', () => {
+  function makeWritableResponse(): ExpressResponse {
+    const response = new EventEmitter() as unknown as ExpressResponse & {
+      status: jest.Mock;
+      setHeader: jest.Mock;
+      end: jest.Mock;
+      writableEnded: boolean;
+    };
+    response.status = jest.fn().mockReturnValue(response);
+    response.setHeader = jest.fn().mockReturnValue(response);
+    response.end = jest.fn(() => {
+      response.writableEnded = true;
+      return response;
+    });
+    response.writableEnded = false;
+    return response;
+  }
+
   function makeController(service?: Partial<ChatsService>) {
     const chatsService = {
       getChatsByUserId: jest.fn().mockResolvedValue([chat]),
@@ -70,6 +89,43 @@ describe('ChatsController', () => {
       'verified-user',
       { title: 'Renamed', ownerUserId: 'attacker' },
     );
+  });
+
+  it('streams messages with userId from the verified session only', async () => {
+    const { controller, chatLoopService } = makeController();
+    const streamResult = {
+      toUIMessageStreamResponse: jest.fn(() => new Response(null)),
+    } as unknown as Awaited<ReturnType<ChatLoopService['createMessageStream']>>;
+    chatLoopService.createMessageStream.mockResolvedValue(streamResult);
+
+    const userMessageId = '0910fd41-1f2f-49de-b1c2-00ff4b3c7c60';
+    await controller.createMessage(
+      'verified-user',
+      chat.id,
+      {
+        userId: 'attacker',
+        message: {
+          id: userMessageId,
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      } as never,
+      new EventEmitter() as Request,
+      makeWritableResponse(),
+    );
+
+    expect(chatLoopService.createMessageStream).toHaveBeenCalledTimes(1);
+    const [call] = chatLoopService.createMessageStream.mock.calls[0] as [
+      Parameters<ChatLoopService['createMessageStream']>[0],
+    ];
+    expect(call).toMatchObject({
+      chatId: chat.id,
+      userId: 'verified-user',
+      message: {
+        id: userMessageId,
+        parts: [{ type: 'text', text: 'Hello' }],
+      },
+    });
+    expect(call.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
   it('returns 404 when the verified user does not own the chat', async () => {

--- a/apps/api/src/chats/chats.controller.spec.ts
+++ b/apps/api/src/chats/chats.controller.spec.ts
@@ -2,6 +2,7 @@
 
 import { NotFoundException } from '@nestjs/common';
 import { ChatsController } from './chats.controller';
+import type { ChatLoopService } from './chat-loop.service';
 import type { ChatsService } from './chats.service';
 import type { Chat } from '../db/schema';
 
@@ -23,8 +24,15 @@ describe('ChatsController', () => {
       updateChat: jest.fn().mockResolvedValue(chat),
       ...service,
     } as unknown as jest.Mocked<ChatsService>;
+    const chatLoopService = {
+      createMessageStream: jest.fn(),
+    } as unknown as jest.Mocked<ChatLoopService>;
 
-    return { controller: new ChatsController(chatsService), chatsService };
+    return {
+      controller: new ChatsController(chatsService, chatLoopService),
+      chatsService,
+      chatLoopService,
+    };
   }
 
   it('lists chats for the verified user, not a client-supplied owner id', async () => {

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -2,29 +2,41 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
   NotFoundException,
   Param,
   ParseUUIDPipe,
   Patch,
   Post,
+  Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBadGatewayResponse,
   ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiBody,
   ApiCookieAuth,
   ApiCreatedResponse,
+  ApiConflictResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiParam,
+  ApiResponse,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import type { Request, Response as ExpressResponse } from 'express';
 import { CurrentUser } from '../auth/auth-context';
 import { SessionAuthGuard } from '../auth/session-auth.guard';
+import { ChatLoopService } from './chat-loop.service';
 import { ChatsService } from './chats.service';
 import {
   ChatResponse,
+  CreateMessageDto,
   CreateChatDto,
   toChatResponse,
   UpdateChatDto,
@@ -36,7 +48,10 @@ import {
 @UseGuards(SessionAuthGuard)
 @Controller('api/v1/chats')
 export class ChatsController {
-  constructor(private readonly chatsService: ChatsService) {}
+  constructor(
+    private readonly chatsService: ChatsService,
+    private readonly chatLoopService: ChatLoopService,
+  ) {}
 
   @Get()
   @ApiOkResponse({ type: ChatResponse, isArray: true })
@@ -79,6 +94,56 @@ export class ChatsController {
     return toChatResponse(chat);
   }
 
+  @Post(':id/messages')
+  @HttpCode(200)
+  @ApiParam({ name: 'id', format: 'uuid' })
+  @ApiBody({ type: CreateMessageDto })
+  @ApiOkResponse({
+    description: 'AI SDK v5 UI-message stream (SSE)',
+    content: {
+      'text/event-stream': {
+        schema: { type: 'string' },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Malformed chat id or invalid message body',
+  })
+  @ApiUnauthorizedResponse()
+  @ApiResponse({
+    status: 402,
+    description: 'No model credential configured for the user',
+  })
+  @ApiNotFoundResponse({ description: 'Chat not found or not owned' })
+  @ApiConflictResponse({ description: 'Message turn already completed' })
+  @ApiBadGatewayResponse({ description: 'Model stream failed' })
+  async createMessage(
+    @CurrentUser() userId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() input: CreateMessageDto,
+    @Req() request: Request,
+    @Res() response: ExpressResponse,
+  ): Promise<void> {
+    const abort = requestAbortSignal(request, response);
+
+    try {
+      const result = await this.chatLoopService.createMessageStream({
+        chatId: id,
+        userId,
+        message: input.message,
+        abortSignal: abort.signal,
+      });
+
+      const streamResponse = result.toUIMessageStreamResponse({
+        onError: () => 'An error occurred.',
+      });
+
+      await writeWebResponse(streamResponse, response, abort.signal);
+    } finally {
+      abort.cleanup();
+    }
+  }
+
   // PATCH (partial update) of a chat resource — RESTful, not an RPC-style verb endpoint.
   @Patch(':id')
   @ApiParam({ name: 'id', format: 'uuid' })
@@ -97,5 +162,57 @@ export class ChatsController {
     }
 
     return toChatResponse(chat);
+  }
+}
+
+function requestAbortSignal(
+  request: Request,
+  response: ExpressResponse,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  const abort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort();
+    }
+  };
+  const abortOnResponseClose = () => {
+    if (!response.writableEnded) {
+      abort();
+    }
+  };
+
+  request.on('aborted', abort);
+  response.on('close', abortOnResponseClose);
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      request.off('aborted', abort);
+      response.off('close', abortOnResponseClose);
+    },
+  };
+}
+
+async function writeWebResponse(
+  streamResponse: Response,
+  response: ExpressResponse,
+  abortSignal: AbortSignal,
+): Promise<void> {
+  response.status(streamResponse.status || 200);
+  streamResponse.headers.forEach((value, key) => {
+    response.setHeader(key, value);
+  });
+
+  if (!streamResponse.body) {
+    response.end();
+    return;
+  }
+
+  try {
+    await pipeline(Readable.fromWeb(streamResponse.body as never), response);
+  } catch (error) {
+    if (!abortSignal.aborted) {
+      throw error;
+    }
   }
 }

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Get,
   HttpCode,
+  HttpException,
+  HttpStatus,
   Logger,
   NotFoundException,
   Param,
@@ -14,7 +16,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
-  ApiBadGatewayResponse,
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
@@ -28,6 +29,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { MissingModelCredentialError } from '../models/model-client';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { Request, Response as ExpressResponse } from 'express';
@@ -119,7 +121,6 @@ export class ChatsController {
   })
   @ApiNotFoundResponse({ description: 'Chat not found or not owned' })
   @ApiConflictResponse({ description: 'Message turn already completed' })
-  @ApiBadGatewayResponse({ description: 'Model stream failed' })
   async createMessage(
     @CurrentUser() userId: string,
     @Param('id', ParseUUIDPipe) id: string,
@@ -148,6 +149,19 @@ export class ChatsController {
       });
 
       await writeWebResponse(streamResponse, response, abort.signal);
+    } catch (error) {
+      // Map the domain credential error to HTTP here (the service stays HTTP-agnostic).
+      if (error instanceof MissingModelCredentialError) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.PAYMENT_REQUIRED,
+            error: 'Payment Required',
+            message: 'No model credential configured.',
+          },
+          HttpStatus.PAYMENT_REQUIRED,
+        );
+      }
+      throw error;
     } finally {
       abort.cleanup();
     }
@@ -195,13 +209,14 @@ function requestAbortSignal(
     }
   };
 
-  request.on('aborted', abort);
+  // `response` 'close' fires on client disconnect (before or during streaming) — this is
+  // the reliable abort signal on Node 20+. (The old request 'aborted' event is deprecated
+  // and does not fire reliably, so it is not used.)
   response.on('close', abortOnResponseClose);
 
   return {
     signal: controller.signal,
     cleanup: () => {
-      request.off('aborted', abort);
       response.off('close', abortOnResponseClose);
     },
   };

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -174,6 +174,11 @@ export class ChatsController {
   }
 }
 
+/**
+ * Creates an abort signal tied to the request and response lifecycle.
+ *
+ * @returns The abort signal and a cleanup function that removes the registered listeners.
+ */
 function requestAbortSignal(
   request: Request,
   response: ExpressResponse,
@@ -202,6 +207,13 @@ function requestAbortSignal(
   };
 }
 
+/**
+ * Writes a web response to an Express response.
+ *
+ * @param streamResponse - The response to send, including status, headers, and optional body
+ * @param response - The Express response to write to
+ * @param abortSignal - The abort signal used to suppress errors after cancellation
+ */
 async function writeWebResponse(
   streamResponse: Response,
   response: ExpressResponse,

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -45,6 +45,8 @@ import {
   UpdateChatDto,
 } from './dto/chats.dto';
 
+const streamLogger = new Logger('ChatStream');
+
 @ApiTags('chats')
 @ApiBearerAuth('bearer')
 @ApiCookieAuth('cookie')
@@ -247,8 +249,22 @@ async function writeWebResponse(
   try {
     await pipeline(Readable.fromWeb(streamResponse.body as never), response);
   } catch (error) {
-    if (!abortSignal.aborted) {
-      throw error;
+    if (abortSignal.aborted) {
+      return;
     }
+    // A mid-stream failure after the status+headers were flushed cannot be turned into
+    // an HTTP error response — re-throwing would trigger ERR_HTTP_HEADERS_SENT. Log and
+    // destroy the connection instead. (Pre-headers failures still throw → exception filter.)
+    if (response.headersSent) {
+      streamLogger.error(
+        'Stream pipeline failed after headers were sent',
+        error instanceof Error ? error.stack : String(error),
+      );
+      response.destroy(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      return;
+    }
+    throw error;
   }
 }

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   HttpCode,
+  Logger,
   NotFoundException,
   Param,
   ParseUUIDPipe,
@@ -48,6 +49,8 @@ import {
 @UseGuards(SessionAuthGuard)
 @Controller('api/v1/chats')
 export class ChatsController {
+  private readonly logger = new Logger(ChatsController.name);
+
   constructor(
     private readonly chatsService: ChatsService,
     private readonly chatLoopService: ChatLoopService,
@@ -135,7 +138,13 @@ export class ChatsController {
       });
 
       const streamResponse = result.toUIMessageStreamResponse({
-        onError: () => 'An error occurred.',
+        onError: (error) => {
+          this.logger.error(
+            'Model stream failed',
+            error instanceof Error ? error.stack : String(error),
+          );
+          return 'An error occurred.';
+        },
       });
 
       await writeWebResponse(streamResponse, response, abort.signal);

--- a/apps/api/src/chats/chats.module.ts
+++ b/apps/api/src/chats/chats.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { TenantDbService } from '../db/tenant-db.service';
+import { ModelsModule } from '../models/models.module';
+import { ChatLoopService } from './chat-loop.service';
 import { ChatsController } from './chats.controller';
 import { ChatsService } from './chats.service';
 
@@ -8,9 +10,9 @@ import { ChatsService } from './chats.service';
 // identity from a verified session. Controllers must never accept ownerUserId from
 // client input; that would recreate the #61 tenant-impersonation IDOR.
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, ModelsModule],
   controllers: [ChatsController],
-  providers: [TenantDbService, ChatsService],
+  providers: [TenantDbService, ChatsService, ChatLoopService],
   exports: [ChatsService],
 })
 export class ChatsModule {}

--- a/apps/api/src/chats/context-builder.ts
+++ b/apps/api/src/chats/context-builder.ts
@@ -63,7 +63,7 @@ export interface BuildContextOptions {
   maxMessages?: number;
 }
 
-const DEFAULT_MAX_MESSAGES = 100;
+export const DEFAULT_MAX_MESSAGES = 100;
 
 /**
  * Extracts the text content from an AI SDK v5 UIMessage parts array.

--- a/apps/api/src/chats/dto/chats.dto.ts
+++ b/apps/api/src/chats/dto/chats.dto.ts
@@ -1,5 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  MaxLength,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
 import type { Chat } from '../../db/schema';
 
 export class CreateChatDto {
@@ -22,6 +34,38 @@ export class UpdateChatDto {
   @MinLength(1)
   @MaxLength(200)
   title?: string;
+}
+
+export class CreateTextMessagePartDto {
+  @ApiProperty({ enum: ['text'] })
+  @IsIn(['text'])
+  type!: 'text';
+
+  @ApiProperty({ minLength: 1, maxLength: 20000 })
+  @IsString()
+  @Matches(/\S/, { message: 'text must not be blank' })
+  @MaxLength(20000)
+  text!: string;
+}
+
+export class CreateMessageBodyDto {
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  id!: string;
+
+  @ApiProperty({ type: () => [CreateTextMessagePartDto] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateTextMessagePartDto)
+  parts!: CreateTextMessagePartDto[];
+}
+
+export class CreateMessageDto {
+  @ApiProperty({ type: () => CreateMessageBodyDto })
+  @ValidateNested()
+  @Type(() => CreateMessageBodyDto)
+  message!: CreateMessageBodyDto;
 }
 
 export class ChatResponse {

--- a/apps/api/src/chats/dto/chats.dto.ts
+++ b/apps/api/src/chats/dto/chats.dto.ts
@@ -1,8 +1,10 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
+  ArrayMaxSize,
   ArrayMinSize,
   IsArray,
+  IsDefined,
   IsIn,
   IsOptional,
   IsString,
@@ -53,16 +55,24 @@ export class CreateMessageBodyDto {
   @IsUUID()
   id!: string;
 
-  @ApiProperty({ type: () => [CreateTextMessagePartDto] })
+  @ApiProperty({
+    type: () => [CreateTextMessagePartDto],
+    minItems: 1,
+    maxItems: 50,
+  })
   @IsArray()
   @ArrayMinSize(1)
+  @ArrayMaxSize(50)
   @ValidateNested({ each: true })
   @Type(() => CreateTextMessagePartDto)
   parts!: CreateTextMessagePartDto[];
 }
 
 export class CreateMessageDto {
+  // @IsDefined is required: without it, an omitted `message` is `undefined` and
+  // @ValidateNested silently passes, so the handler would deref `input.message.id`.
   @ApiProperty({ type: () => CreateMessageBodyDto })
+  @IsDefined()
   @ValidateNested()
   @Type(() => CreateMessageBodyDto)
   message!: CreateMessageBodyDto;

--- a/apps/api/src/db/migrations/0007_wise_paladin.sql
+++ b/apps/api/src/db/migrations/0007_wise_paladin.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "messages" ADD COLUMN "usage" jsonb;--> statement-breakpoint
+ALTER TABLE "messages" ADD COLUMN "in_reply_to" uuid;--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_in_reply_to_messages_id_fk" FOREIGN KEY ("in_reply_to") REFERENCES "public"."messages"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/api/src/db/migrations/0008_smiling_rattler.sql
+++ b/apps/api/src/db/migrations/0008_smiling_rattler.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "messages_in_reply_to_unique_idx" ON "messages" USING btree ("in_reply_to");

--- a/apps/api/src/db/migrations/meta/0007_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,699 @@
+{
+  "id": "82fd3cd5-1013-4135-bc0d-30dade8e2eb9",
+  "prevId": "02008b20-b252-4522-9872-a13e9f7b5436",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_created_idx": {
+          "name": "sessions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "chat_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_owner_updated_idx": {
+          "name": "chats_owner_updated_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_owner_user_id_users_id_fk": {
+          "name": "chats_owner_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "chats_owner": {
+          "name": "chats_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "owner_user_id = current_setting('app.current_user_id', true)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "messages_seq_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_created_idx": {
+          "name": "messages_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_chat_seq_idx": {
+          "name": "messages_chat_seq_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_user_id_users_id_fk": {
+          "name": "messages_sender_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_in_reply_to_messages_id_fk": {
+          "name": "messages_in_reply_to_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "in_reply_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "messages_owner": {
+          "name": "messages_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "chat_id IN (\n        SELECT id FROM chats\n        WHERE owner_user_id = current_setting('app.current_user_id', true)\n      )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.chat_visibility": {
+      "name": "chat_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/0008_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,714 @@
+{
+  "id": "93c0ae86-7a65-4ee8-817b-3d2802cb384d",
+  "prevId": "82fd3cd5-1013-4135-bc0d-30dade8e2eb9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_device_type": {
+          "name": "credential_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_backed_up": {
+          "name": "credential_backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_user_id_users_id_fk": {
+          "name": "authenticators_user_id_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credential_id_unique": {
+          "name": "authenticators_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_created_idx": {
+          "name": "sessions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'New chat'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "chat_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chats_owner_updated_idx": {
+          "name": "chats_owner_updated_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_owner_user_id_users_id_fk": {
+          "name": "chats_owner_user_id_users_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "chats_owner": {
+          "name": "chats_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "owner_user_id = current_setting('app.current_user_id', true)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "messages_seq_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "role": {
+          "name": "role",
+          "type": "message_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_user_id": {
+          "name": "sender_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_chat_created_idx": {
+          "name": "messages_chat_created_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_chat_seq_idx": {
+          "name": "messages_chat_seq_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_in_reply_to_unique_idx": {
+          "name": "messages_in_reply_to_unique_idx",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_user_id_users_id_fk": {
+          "name": "messages_sender_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_in_reply_to_messages_id_fk": {
+          "name": "messages_in_reply_to_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "in_reply_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "messages_owner": {
+          "name": "messages_owner",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "public"
+          ],
+          "using": "chat_id IN (\n        SELECT id FROM chats\n        WHERE owner_user_id = current_setting('app.current_user_id', true)\n      )"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.chat_visibility": {
+      "name": "chat_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.message_role": {
+      "name": "message_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782773757483,
       "tag": "0007_wise_paladin",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782776766411,
+      "tag": "0008_smiling_rattler",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782763011177,
       "tag": "0006_famous_adam_warlock",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782773757483,
+      "tag": "0007_wise_paladin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/chats.ts
+++ b/apps/api/src/db/schema/chats.ts
@@ -9,6 +9,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
@@ -105,6 +106,7 @@ export const messages = pgTable(
     index('messages_chat_created_idx').on(t.chatId, t.createdAt),
     // Ordering index: history is read with ORDER BY (chat_id, seq).
     index('messages_chat_seq_idx').on(t.chatId, t.seq),
+    uniqueIndex('messages_in_reply_to_unique_idx').on(t.inReplyTo),
     // RLS: access messages only when their chat is owned by the current user
     pgPolicy('messages_owner', {
       using: sql`chat_id IN (

--- a/apps/api/src/db/schema/chats.ts
+++ b/apps/api/src/db/schema/chats.ts
@@ -1,5 +1,6 @@
 import { InferSelectModel } from 'drizzle-orm';
 import {
+  type AnyPgColumn,
   bigint,
   index,
   jsonb,
@@ -92,6 +93,10 @@ export const messages = pgTable(
     attachments: jsonb('attachments')
       .notNull()
       .default(sql`'[]'::jsonb`),
+    usage: jsonb('usage'),
+    inReplyTo: uuid('in_reply_to').references((): AnyPgColumn => messages.id, {
+      onDelete: 'set null',
+    }),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/api/src/models/fake-model-client.ts
+++ b/apps/api/src/models/fake-model-client.ts
@@ -1,6 +1,6 @@
 import type { TextStreamPart, streamText } from 'ai';
 
-import type { ModelClient } from './model-client';
+import type { ModelClient, ModelStreamInput } from './model-client';
 
 type TextStream = AsyncIterable<string> & ReadableStream<string>;
 type FullStream = AsyncIterable<TextStreamPart<never>> &
@@ -10,11 +10,21 @@ export function createFakeModelClient(responses: string[]): ModelClient {
   let responseIndex = 0;
 
   return {
-    streamText() {
+    streamText(input: ModelStreamInput) {
       const response =
         responses.length === 0
           ? ''
           : responses[responseIndex++ % responses.length];
+
+      void input.onFinish?.({
+        text: response,
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+        finishReason: 'stop',
+      });
 
       return createFakeStreamTextResult(response);
     },

--- a/apps/api/src/models/fake-model-client.ts
+++ b/apps/api/src/models/fake-model-client.ts
@@ -6,6 +6,12 @@ type TextStream = AsyncIterable<string> & ReadableStream<string>;
 type FullStream = AsyncIterable<TextStreamPart<never>> &
   ReadableStream<TextStreamPart<never>>;
 
+/**
+ * Creates a fake model client that cycles through preset text responses.
+ *
+ * @param responses - The text responses returned by successive `streamText` calls
+ * @returns A model client that streams the provided responses in order
+ */
 export function createFakeModelClient(responses: string[]): ModelClient {
   let responseIndex = 0;
 

--- a/apps/api/src/models/model-client.spec.ts
+++ b/apps/api/src/models/model-client.spec.ts
@@ -74,10 +74,12 @@ describe('ModelClient', () => {
     const client = createOpenAIModelClient(credential, 'gpt-test');
 
     const abortSignal = AbortSignal.timeout(1000);
+    const onFinish = jest.fn();
     client.streamText({
       messages,
       system: 'stable system',
       abortSignal,
+      onFinish,
     });
 
     expect(createOpenAIMock).toHaveBeenCalledWith({
@@ -89,6 +91,7 @@ describe('ModelClient', () => {
       messages,
       system: 'stable system',
       abortSignal,
+      onFinish,
     });
   });
 
@@ -113,6 +116,24 @@ describe('ModelClient', () => {
       messages,
       system: undefined,
       abortSignal: undefined,
+      onFinish: undefined,
+    });
+  });
+
+  it('passes onFinish through to the fake client', async () => {
+    const client = createFakeModelClient(['done']);
+    const onFinish = jest.fn();
+
+    await collectText(client.streamText({ messages, onFinish }).textStream);
+
+    expect(onFinish).toHaveBeenCalledWith({
+      text: 'done',
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+      },
+      finishReason: 'stop',
     });
   });
 

--- a/apps/api/src/models/model-client.ts
+++ b/apps/api/src/models/model-client.ts
@@ -1,9 +1,19 @@
-import type { ModelMessage, streamText } from 'ai';
+import type {
+  FinishReason,
+  LanguageModelUsage,
+  ModelMessage,
+  streamText,
+} from 'ai';
 
 export interface ModelStreamInput {
   messages: ModelMessage[];
   system?: string;
   abortSignal?: AbortSignal;
+  onFinish?: (event: {
+    text: string;
+    usage: LanguageModelUsage;
+    finishReason: FinishReason;
+  }) => void | Promise<void>;
 }
 
 export interface ModelClient {

--- a/apps/api/src/models/models.service.ts
+++ b/apps/api/src/models/models.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 import {
   resolveModelCredential,
@@ -10,11 +11,16 @@ import { createOpenAIModelClient } from './openai-model-client';
 
 @Injectable()
 export class ModelsService {
+  constructor(private readonly config: ConfigService) {}
+
   resolveModelCredential(
     userId: string,
     resolveCredential?: ModelCredentialResolver,
   ): Promise<string> {
-    return resolveModelCredential(userId, resolveCredential);
+    return resolveModelCredential(
+      userId,
+      resolveCredential ?? (() => this.config.get<string>('OPENAI_API_KEY')),
+    );
   }
 
   requireModelCredential(

--- a/apps/api/src/models/openai-model-client.ts
+++ b/apps/api/src/models/openai-model-client.ts
@@ -9,6 +9,13 @@ import {
 
 export const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
 
+/**
+ * Creates a model client for streaming text with OpenAI.
+ *
+ * @param apiKey - OpenAI API key
+ * @param model - The model to use for generated text
+ * @returns A model client that streams text using the configured OpenAI model
+ */
 export function createOpenAIModelClient(
   apiKey: string,
   model = DEFAULT_OPENAI_MODEL,

--- a/apps/api/src/models/openai-model-client.ts
+++ b/apps/api/src/models/openai-model-client.ts
@@ -24,6 +24,7 @@ export function createOpenAIModelClient(
         messages: input.messages,
         system: input.system,
         abortSignal: input.abortSignal,
+        onFinish: input.onFinish,
       });
     },
   };

--- a/apps/api/test/chats-messages.e2e-spec.ts
+++ b/apps/api/test/chats-messages.e2e-spec.ts
@@ -30,6 +30,12 @@ const cookieOf = (res: request.Response): string => {
   return '';
 };
 
+/**
+ * Parses SSE data events into JSON values.
+ *
+ * @param body - The SSE payload to parse
+ * @returns The parsed JSON values from each `data: ` event, excluding `[DONE]`
+ */
 function parseSseEvents(body: string): unknown[] {
   return body
     .split('\n\n')
@@ -40,6 +46,11 @@ function parseSseEvents(body: string): unknown[] {
     .map((data): unknown => JSON.parse(data) as unknown);
 }
 
+/**
+ * Extracts streamed text content from an SSE payload.
+ *
+ * @returns The concatenated `delta` values from `text-delta` events.
+ */
 function streamedText(body: string): string {
   return parseSseEvents(body)
     .filter(
@@ -52,6 +63,14 @@ function streamedText(body: string): string {
     .join('');
 }
 
+/**
+ * Waits until a condition becomes true.
+ *
+ * @param condition - The condition to poll
+ * @param timeoutMs - The maximum time to wait in milliseconds
+ * @returns A promise that resolves when the condition becomes true
+ * @throws Error when the condition does not become true before the timeout expires
+ */
 async function waitFor(
   condition: () => boolean,
   timeoutMs = 1000,
@@ -209,6 +228,13 @@ d('POST /api/v1/chats/:id/messages — streaming loop', () => {
   let cookieB = '';
   let chatA = '';
 
+  /**
+   * Registers a user and returns the session cookie and user ID.
+   *
+   * @param email - The email address to register
+   * @param name - The display name to register
+   * @returns The session cookie and created user ID
+   */
   async function register(
     email: string,
     name: string,
@@ -223,6 +249,13 @@ d('POST /api/v1/chats/:id/messages — streaming loop', () => {
     return { cookie: cookieOf(res), userId: userId as string };
   }
 
+  /**
+   * Creates a chat and returns its identifier.
+   *
+   * @param cookie - Session cookie for the authenticated user
+   * @param title - Chat title to submit
+   * @returns The created chat ID
+   */
   async function createChat(cookie: string, title: string): Promise<string> {
     const res = await request(http)
       .post('/api/v1/chats')
@@ -235,6 +268,12 @@ d('POST /api/v1/chats/:id/messages — streaming loop', () => {
     return chatId as string;
   }
 
+  /**
+   * Loads the messages visible to the test user for a chat.
+   *
+   * @param chatId - The chat identifier
+   * @returns The messages returned for that chat in the current test tenant context
+   */
   async function listMessages(chatId: string): Promise<unknown[]> {
     return tenantDb.runAs(userAId, (tx) =>
       new MessagesRepository(tx).findByChatId(chatId, userAId),

--- a/apps/api/test/chats-messages.e2e-spec.ts
+++ b/apps/api/test/chats-messages.e2e-spec.ts
@@ -15,6 +15,7 @@ import { AppModule } from './../src/app.module';
 import { configureApp } from './../src/app.setup';
 import { TenantDbService } from './../src/db/tenant-db.service';
 import { MessagesRepository } from './../src/chats/chats-repository';
+import { MissingModelCredentialError } from './../src/models/model-client';
 import { ModelsService } from './../src/models/models.service';
 
 const hasDb = !!process.env.POSTGRES_URL;
@@ -123,6 +124,12 @@ class FakeStreamingModelClient {
         });
         controller.enqueue({ type: 'text-end', id: 'text-1' });
 
+        if (input.abortSignal?.aborted) {
+          turn.aborted = true;
+          controller.error(new Error('aborted'));
+          return;
+        }
+
         if (this.shouldFinish) {
           await input.onFinish?.({
             text: response,
@@ -178,11 +185,7 @@ class FakeModelsService {
 
   resolveModelCredential(userId: string): string {
     if (!this.credential) {
-      const err = new Error(
-        `No model credential configured for user ${userId}.`,
-      );
-      err.name = 'MissingModelCredentialError';
-      throw Object.assign(err, { code: 'missing_model_credential', userId });
+      throw new MissingModelCredentialError(userId);
     }
 
     return this.credential;
@@ -389,6 +392,34 @@ d('POST /api/v1/chats/:id/messages — streaming loop', () => {
 
     expect(res.status).toBe(402);
     expect(res.body).not.toMatchObject({ stack: expect.anything() });
+    expect(models.client.turns).toHaveLength(0);
+    await expect(listMessages(chatA)).resolves.toEqual(before);
+  });
+
+  it('returns 409 when the client message id collides with a non-user row', async () => {
+    const collisionId = crypto.randomUUID();
+    await tenantDb.runAs(userAId, (tx) =>
+      new MessagesRepository(tx).create({
+        id: collisionId,
+        chatId: chatA,
+        role: 'assistant',
+        senderUserId: null,
+        parts: [{ type: 'text', text: 'Existing assistant' }],
+      }),
+    );
+    const before = await listMessages(chatA);
+
+    const res = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: collisionId,
+          parts: [{ type: 'text', text: 'Colliding prompt' }],
+        },
+      });
+
+    expect(res.status).toBe(409);
     expect(models.client.turns).toHaveLength(0);
     await expect(listMessages(chatA)).resolves.toEqual(before);
   });

--- a/apps/api/test/chats-messages.e2e-spec.ts
+++ b/apps/api/test/chats-messages.e2e-spec.ts
@@ -1,0 +1,565 @@
+/**
+ * Chat message streaming e2e (#55) — real HTTP + Postgres, fake model client.
+ *
+ * Requires POSTGRES_URL to point at a migrated database. Without it the suite is
+ * skipped so offline `pnpm test` remains usable; scripts/rls-test.sh provides the
+ * real database gate.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { type ModelMessage, type streamText } from 'ai';
+import { AppModule } from './../src/app.module';
+import { configureApp } from './../src/app.setup';
+import { TenantDbService } from './../src/db/tenant-db.service';
+import { MessagesRepository } from './../src/chats/chats-repository';
+import { ModelsService } from './../src/models/models.service';
+
+const hasDb = !!process.env.POSTGRES_URL;
+const d = hasDb ? describe : describe.skip;
+
+const cookieOf = (res: request.Response): string => {
+  const set = (res.headers['set-cookie'] as unknown as string[]) ?? [];
+  for (const c of set) {
+    const m = /llame_session=([^;]+)/.exec(c);
+    if (m) return `llame_session=${m[1]}`;
+  }
+  return '';
+};
+
+function parseSseEvents(body: string): unknown[] {
+  return body
+    .split('\n\n')
+    .map((event) => event.trim())
+    .filter((event) => event.startsWith('data: '))
+    .map((event) => event.slice('data: '.length))
+    .filter((data) => data !== '[DONE]')
+    .map((data): unknown => JSON.parse(data) as unknown);
+}
+
+function streamedText(body: string): string {
+  return parseSseEvents(body)
+    .filter(
+      (event): event is { type: 'text-delta'; delta: string } =>
+        typeof event === 'object' &&
+        event !== null &&
+        (event as { type?: unknown }).type === 'text-delta',
+    )
+    .map((event) => event.delta)
+    .join('');
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const started = Date.now();
+  while (!condition()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error('Timed out waiting for condition');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+type FakeTurn = {
+  messages: ModelMessage[];
+  abortSignal?: AbortSignal;
+  aborted: boolean;
+};
+
+class FakeStreamingModelClient {
+  readonly turns: FakeTurn[] = [];
+  responses: string[] = ['fake assistant'];
+  shouldFinish = true;
+  delayMs = 0;
+
+  streamText(input: {
+    messages: ModelMessage[];
+    abortSignal?: AbortSignal;
+    onFinish?: (event: {
+      text: string;
+      usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+      finishReason: string;
+    }) => void | Promise<void>;
+  }): ReturnType<typeof streamText> {
+    const response =
+      this.responses[this.turns.length] ?? this.responses[0] ?? '';
+    const turn: FakeTurn = {
+      messages: input.messages,
+      abortSignal: input.abortSignal,
+      aborted: false,
+    };
+    this.turns.push(turn);
+
+    input.abortSignal?.addEventListener('abort', () => {
+      turn.aborted = true;
+    });
+
+    const stream = new ReadableStream({
+      start: async (controller) => {
+        controller.enqueue({
+          type: 'start',
+          messageId: `fake-${this.turns.length}`,
+        });
+        controller.enqueue({ type: 'text-start', id: 'text-1' });
+
+        if (this.delayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+        }
+
+        if (input.abortSignal?.aborted) {
+          turn.aborted = true;
+          controller.error(new Error('aborted'));
+          return;
+        }
+
+        controller.enqueue({
+          type: 'text-delta',
+          id: 'text-1',
+          delta: response,
+        });
+        controller.enqueue({ type: 'text-end', id: 'text-1' });
+
+        if (this.shouldFinish) {
+          await input.onFinish?.({
+            text: response,
+            usage: { inputTokens: 3, outputTokens: 5, totalTokens: 8 },
+            finishReason: 'stop',
+          });
+          controller.enqueue({ type: 'finish' });
+        }
+
+        controller.close();
+      },
+    });
+
+    const toResponse = () => {
+      const sse = stream.pipeThrough(
+        new TransformStream({
+          transform(part, controller) {
+            controller.enqueue(`data: ${JSON.stringify(part)}\n\n`);
+          },
+          flush(controller) {
+            controller.enqueue('data: [DONE]\n\n');
+          },
+        }),
+      );
+      return new Response(sse.pipeThrough(new TextEncoderStream()), {
+        headers: {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+          'x-vercel-ai-ui-message-stream': 'v1',
+        },
+      });
+    };
+
+    return {
+      text: Promise.resolve(response),
+      textStream: new ReadableStream({
+        start(controller) {
+          controller.enqueue(response);
+          controller.close();
+        },
+      }) as never,
+      fullStream: new ReadableStream() as never,
+      consumeStream: async () => {},
+      toUIMessageStreamResponse: toResponse,
+    } as unknown as ReturnType<typeof streamText>;
+  }
+}
+
+class FakeModelsService {
+  credential: string | null = 'sk-test';
+  readonly client = new FakeStreamingModelClient();
+
+  resolveModelCredential(userId: string): string {
+    if (!this.credential) {
+      const err = new Error(
+        `No model credential configured for user ${userId}.`,
+      );
+      err.name = 'MissingModelCredentialError';
+      throw Object.assign(err, { code: 'missing_model_credential', userId });
+    }
+
+    return this.credential;
+  }
+
+  createOpenAIClient() {
+    return this.client;
+  }
+}
+
+d('POST /api/v1/chats/:id/messages — streaming loop', () => {
+  let app: INestApplication;
+  let http: import('http').Server;
+  let models: FakeModelsService;
+  let tenantDb: TenantDbService;
+
+  const tag = Date.now();
+  const password = 'password123';
+  let cookieA = '';
+  let userAId = '';
+  let cookieB = '';
+  let chatA = '';
+
+  async function register(
+    email: string,
+    name: string,
+  ): Promise<{ cookie: string; userId: string }> {
+    const res = await request(http)
+      .post('/auth/v1/register')
+      .send({ email, password, name });
+    expect(res.status).toBe(201);
+    const body = res.body as { user?: { id?: unknown } };
+    const userId = body.user?.id;
+    expect(typeof userId).toBe('string');
+    return { cookie: cookieOf(res), userId: userId as string };
+  }
+
+  async function createChat(cookie: string, title: string): Promise<string> {
+    const res = await request(http)
+      .post('/api/v1/chats')
+      .set('Cookie', cookie)
+      .send({ title });
+    expect(res.status).toBe(201);
+    const body = res.body as { id?: unknown };
+    const chatId = body.id;
+    expect(typeof chatId).toBe('string');
+    return chatId as string;
+  }
+
+  async function listMessages(chatId: string): Promise<unknown[]> {
+    return tenantDb.runAs(userAId, (tx) =>
+      new MessagesRepository(tx).findByChatId(chatId, userAId),
+    );
+  }
+
+  beforeAll(async () => {
+    models = new FakeModelsService();
+    const mod = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ModelsService)
+      .useValue(models)
+      .compile();
+
+    app = mod.createNestApplication();
+    configureApp(app);
+    await app.init();
+    http = app.getHttpServer();
+    tenantDb = app.get(TenantDbService);
+
+    const userA = await register(`stream-a-${tag}@example.com`, 'Stream A');
+    cookieA = userA.cookie;
+    userAId = userA.userId;
+    cookieB = (await register(`stream-b-${tag}@example.com`, 'Stream B'))
+      .cookie;
+    chatA = await createChat(cookieA, 'Streaming Chat');
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    models.credential = 'sk-test';
+    models.client.turns.length = 0;
+    models.client.responses = ['fake assistant'];
+    models.client.shouldFinish = true;
+    models.client.delayMs = 0;
+  });
+
+  it('streams a UI-message SSE reply and persists user + assistant with usage', async () => {
+    models.client.responses = ['hello from model'];
+    const userMessageId = crypto.randomUUID();
+
+    const res = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: userMessageId,
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.headers['x-vercel-ai-ui-message-stream']).toBe('v1');
+    expect(streamedText(res.text)).toBe('hello from model');
+    expect(models.client.turns).toHaveLength(1);
+
+    const messages = await listMessages(chatA);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: userMessageId,
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        }),
+        expect.objectContaining({
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'hello from model' }],
+          usage: expect.objectContaining({
+            inputTokens: 3,
+            outputTokens: 5,
+            totalTokens: 8,
+            finishReason: 'stop',
+          }),
+          inReplyTo: userMessageId,
+        }),
+      ]),
+    );
+  });
+
+  it('returns 404 and writes nothing for a cross-tenant chat', async () => {
+    const before = await listMessages(chatA);
+
+    const res = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieB)
+      .send({
+        message: {
+          id: crypto.randomUUID(),
+          parts: [{ type: 'text', text: 'steal' }],
+        },
+      });
+
+    expect(res.status).toBe(404);
+    expect(models.client.turns).toHaveLength(0);
+    await expect(listMessages(chatA)).resolves.toEqual(before);
+  });
+
+  it('aborts the model call and does not persist an assistant message', async () => {
+    models.client.delayMs = 200;
+    const userMessageId = crypto.randomUUID();
+
+    const pending = request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: userMessageId,
+          parts: [{ type: 'text', text: 'Abort me' }],
+        },
+      });
+    const pendingResponse = pending.then((res) => res);
+
+    await waitFor(() => models.client.turns.length === 1);
+    pending.abort();
+
+    await expect(pendingResponse).rejects.toThrow();
+    await waitFor(() => models.client.turns[0]?.aborted === true);
+
+    expect(models.client.turns).toHaveLength(1);
+    expect(models.client.turns[0].aborted).toBe(true);
+    const messages = await listMessages(chatA);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: userMessageId, role: 'user' }),
+      ]),
+    );
+    expect(
+      messages.some(
+        (m) =>
+          typeof m === 'object' &&
+          m !== null &&
+          (m as { inReplyTo?: unknown }).inReplyTo === userMessageId,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns 402 before any write when the user has no model credential', async () => {
+    models.credential = null;
+    const before = await listMessages(chatA);
+
+    const res = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: crypto.randomUUID(),
+          parts: [{ type: 'text', text: 'No key' }],
+        },
+      });
+
+    expect(res.status).toBe(402);
+    expect(res.body).not.toMatchObject({ stack: expect.anything() });
+    expect(models.client.turns).toHaveLength(0);
+    await expect(listMessages(chatA)).resolves.toEqual(before);
+  });
+
+  it('retries a completed turn without a second model call or duplicate user row', async () => {
+    models.client.responses = ['first answer'];
+    const userMessageId = crypto.randomUUID();
+
+    const first = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: userMessageId,
+          parts: [{ type: 'text', text: 'Once' }],
+        },
+      });
+    expect(first.status).toBe(200);
+
+    const second = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: userMessageId,
+          parts: [{ type: 'text', text: 'Once' }],
+        },
+      });
+
+    expect(second.status).toBe(409);
+    expect(models.client.turns).toHaveLength(1);
+
+    const messages = await listMessages(chatA);
+    expect(
+      messages.filter(
+        (m) =>
+          typeof m === 'object' &&
+          m !== null &&
+          (m as { id?: unknown }).id === userMessageId,
+      ),
+    ).toHaveLength(1);
+    expect(
+      messages.filter(
+        (m) =>
+          typeof m === 'object' &&
+          m !== null &&
+          (m as { inReplyTo?: unknown }).inReplyTo === userMessageId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('retries an aborted turn by reusing the user row', async () => {
+    models.client.shouldFinish = false;
+    const userMessageId = crypto.randomUUID();
+
+    const failed = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: userMessageId,
+          parts: [{ type: 'text', text: 'Try again' }],
+        },
+      });
+    expect(failed.status).toBe(200);
+
+    models.client.shouldFinish = true;
+    models.client.responses = ['retry answer'];
+    const retried = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: userMessageId,
+          parts: [{ type: 'text', text: 'Try again' }],
+        },
+      });
+
+    expect(retried.status).toBe(200);
+    expect(models.client.turns).toHaveLength(2);
+
+    const messages = await listMessages(chatA);
+    expect(
+      messages.filter(
+        (m) =>
+          typeof m === 'object' &&
+          m !== null &&
+          (m as { id?: unknown }).id === userMessageId,
+      ),
+    ).toHaveLength(1);
+    expect(
+      messages.filter(
+        (m) =>
+          typeof m === 'object' &&
+          m !== null &&
+          (m as { inReplyTo?: unknown }).inReplyTo === userMessageId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('isolates overlapping turns to history capped at each user message seq', async () => {
+    models.client.delayMs = 50;
+    models.client.responses = ['answer one', 'answer two'];
+    const firstId = crypto.randomUUID();
+    const secondId = crypto.randomUUID();
+
+    const firstRequest = request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: firstId,
+          parts: [{ type: 'text', text: 'Prompt one' }],
+        },
+      });
+    const firstResponse = firstRequest.then((res) => res);
+    await waitFor(() => models.client.turns.length === 1);
+
+    const secondResponse = request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: secondId,
+          parts: [{ type: 'text', text: 'Prompt two' }],
+        },
+      });
+
+    const [first, second] = await Promise.all([firstResponse, secondResponse]);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(models.client.turns).toHaveLength(2);
+
+    const contextTexts = models.client.turns.map((turn) =>
+      JSON.stringify(turn.messages),
+    );
+    const firstContextText = contextTexts.find((text) =>
+      text.includes('Prompt one'),
+    );
+    const secondContextText = contextTexts.find((text) =>
+      text.includes('Prompt two'),
+    );
+    expect(firstContextText).toBeDefined();
+    expect(firstContextText).not.toContain('Prompt two');
+    expect(secondContextText).toBeDefined();
+
+    const messages = await listMessages(chatA);
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'assistant', inReplyTo: firstId }),
+        expect.objectContaining({ role: 'assistant', inReplyTo: secondId }),
+      ]),
+    );
+  });
+
+  it('rejects malformed bodies before any write', async () => {
+    const before = await listMessages(chatA);
+
+    const res = await request(http)
+      .post(`/api/v1/chats/${chatA}/messages`)
+      .set('Cookie', cookieA)
+      .send({
+        message: {
+          id: crypto.randomUUID(),
+          parts: [{ type: 'text', text: '' }],
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(models.client.turns).toHaveLength(0);
+    await expect(listMessages(chatA)).resolves.toEqual(before);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#55** — the v0.1 single-model streaming Q&A loop in `apps/api`, replacing the `langgraph-supervisor` path. One user message → **one streaming model call** → persisted, with no worker, queue, tools, or supervisor. Per the spec on #55 and SPEC §22.0; verified against `vercel/ai-chatbot` (same stack).

New endpoint: **`POST /api/v1/chats/:id/messages`** (guarded, `ParseUUIDPipe` on `:id`) — the client posts only the new user message (with a client-generated `message.id`); the server loads history from the DB, builds cache-aware context (`ContextBuilder`, #53), calls one `ModelClient.streamText` (#54) with the user's key, streams an AI SDK v5 UI-message stream (SSE), and persists the assistant message + token usage in `onFinish`.

## Design (load-bearing invariants)

- **No DB transaction held during streaming** — two short `runAs` transactions: persist-user + load-history before the stream, persist-assistant + usage in `onFinish`. The model stream holds no DB.
- **Identity only from the verified session** (`@CurrentUser` → `runAs` → RLS); never from client input. Cross-tenant access → 404, RLS-enforced.
- **Fail-fast before any write:** model credential (402), ownership (404), idempotency all resolve before the user message is persisted.
- **Turn isolation:** context capped at `seq <= userSeq`; the assistant records `inReplyTo`.
- **Idempotency in the datastore:** client `message.id` is the key; a unique index on `messages(in_reply_to)` makes one-assistant-per-turn a DB invariant; a foreign-id collision returns 409 (not a 500).
- **Token usage captured** on finish (the #56 telemetry seam).

## Commits
- `feat(api): add streaming chat message loop` — endpoint, `ChatLoopService`, `ModelClient.onFinish`, migration `0007` (`usage`, `in_reply_to`), e2e.
- `fix(api): harden streaming chat loop` — applied a high-effort multi-angle code review: collapsed a redundant 3rd transaction (R3), `onFinish` always persists completed generations + logs failures, coordinated abort handling, migration `0008` unique index on `in_reply_to` + idempotent assistant insert, foreign-`message.id` → 409, bounded history `LIMIT`, stream-error logging, identity + collision tests.

## Verification
All gate-checked: `lint` · `test` (50 pass, 7 DB-skip) · `build` · `db:check`. `apps/api/scripts/rls-test.sh` proves cross-tenant RLS (7/7) and runs the auth + chat e2e (18 tests): streaming, persistence + usage, cross-tenant 404, missing-credential-leaves-history-clean, idempotent retry (model called once), abort writes no assistant, turn isolation.

## Out of scope (deferred, tracked)
Durable worker/queue (#48/#50, v0.2); refresh-safe resumable replay (#49); budgets + cost/cache aggregation (#56); lineage compaction (#57); eval set (#58); tools/multi-step; full BYOK vault (v0.4). Strict per-chat generation serialization is deferred (the boundary cap + idempotency prevent corruption + double-row; full single-flight needs the v0.2 queue).

Closes #55.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #55: adds a single-model streaming Q&A loop via POST `/api/v1/chats/:id/messages`. Streams `ai` UI-message SSE, builds server-side context, and saves the assistant reply with token usage, with stricter validation, idempotency, abort handling, and resilient mid-stream error handling.

- New Features
  - New guarded endpoint `POST /api/v1/chats/:id/messages` that accepts a client `message.id`, streams one model call, and persists on finish.
  - Server-only identity and context: owner-scoped history, turn isolation (context ≤ user seq), fixed system prompt, no DB transaction held during streaming, and chat `updatedAt` bumped on new turns.
  - Idempotent turns: client `message.id` is the key; one assistant reply per turn via `messages.in_reply_to` (unique index). 409 on completed turns, id reuse with different content, or foreign-id collision.
  - Clear errors and abort-safe: 400 for invalid bodies (required `message`, bounded `parts`), 402 when no model credential, 404 for cross-tenant/missing chat; aborts never write an assistant. Mid-stream pipeline failures after headers are sent are logged and the connection is closed (no re-throw); pre-header errors still bubble. OpenAPI and DTOs updated; history reads are bounded; e2e coverage added.

- Migration
  - Run DB migrations adding `messages.usage`, `messages.in_reply_to`, and a unique index on `messages.in_reply_to`.

<sup>Written for commit 2c5d03e38133a98226fb01396c71e18e29ce9ab9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/v1/chats/:id/messages` with live SSE streaming for chat replies.
  * Replies are persisted with usage details and finish reason, with retry-safe, idempotent client message IDs.
* **Bug Fixes**
  * Added fail-fast handling for missing credentials (402), invalid inputs (400), completed-turn collisions (409), and cross-tenant access (404).
  * Improved abort behavior so aborted streams don’t persist assistant replies.
* **Documentation**
  * Updated API documentation and DTO validation for the new message creation endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->