### PR TITLE
docs(design): add DESIGN.md — semantic design system reference

### DIFF
--- a/.agents/skills/design-md/README.md
+++ b/.agents/skills/design-md/README.md
@@ -1,0 +1,34 @@
+# Stitch Design System Documentation Skill
+
+## Install
+
+```bash
+npx skills add google-labs-code/stitch-skills --skill design-md --global
+```
+
+## Example Prompt
+
+```text
+Analyze my Furniture Collection project's Home screen and generate a comprehensive DESIGN.md file documenting the design system.
+```
+
+## Skill Structure
+
+This repository follows the **Agent Skills** open standard. Each skill is self-contained with its own logic, workflow, and reference materials.
+
+```text
+design-md/
+├── SKILL.md           — Core instructions & workflow
+├── examples/          — Sample DESIGN.md outputs
+└── README.md          — This file
+```
+
+## How it Works
+
+When activated, the agent follows a structured design analysis pipeline:
+
+1. **Retrieval**: Uses the Stitch MCP Server to fetch project screens, HTML code, and design metadata.
+2. **Extraction**: Identifies design tokens including colors, typography, spacing, and component patterns.
+3. **Translation**: Converts technical CSS/Tailwind values into descriptive, natural design language.
+4. **Synthesis**: Generates a comprehensive DESIGN.md following the semantic design system format.
+5. **Alignment**: Ensures output follows Stitch Effective Prompting Guide principles for optimal screen generation.

--- a/.agents/skills/design-md/SKILL.md
+++ b/.agents/skills/design-md/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: design-md
+description: Analyze Stitch projects and synthesize a semantic design system into DESIGN.md files
+allowed-tools:
+  - "stitch*:*"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Stitch DESIGN.md Skill
+
+You are an expert Design Systems Lead. Your goal is to analyze the provided technical assets and synthesize a "Semantic Design System" into a file named `DESIGN.md`.
+
+## Overview
+
+This skill helps you create `DESIGN.md` files that serve as the "source of truth" for prompting Stitch to generate new screens that align perfectly with existing design language. Stitch interprets design through "Visual Descriptions" supported by specific color values.
+
+## Prerequisites
+
+- Access to the Stitch MCP Server
+- A Stitch project with at least one designed screen
+- Access to the Stitch Effective Prompting Guide: https://stitch.withgoogle.com/docs/learn/prompting/
+
+## The Goal
+
+The `DESIGN.md` file will serve as the "source of truth" for prompting Stitch to generate new screens that align perfectly with the existing design language. Stitch interprets design through "Visual Descriptions" supported by specific color values.
+
+## Retrieval and Networking
+
+To analyze a Stitch project, you must retrieve screen metadata and design assets using the Stitch MCP Server tools:
+
+1. **Namespace discovery**: Run `list_tools` to find the Stitch MCP prefix. Use this prefix (e.g., `mcp_stitch:`) for all subsequent calls.
+
+2. **Project lookup** (if Project ID is not provided):
+   - Call `[prefix]:list_projects` with `filter: "view=owned"` to retrieve all user projects
+   - Identify the target project by title or URL pattern
+   - Extract the Project ID from the `name` field (e.g., `projects/13534454087919359824`)
+
+3. **Screen lookup** (if Screen ID is not provided):
+   - Call `[prefix]:list_screens` with the `projectId` (just the numeric ID, not the full path)
+   - Review screen titles to identify the target screen (e.g., "Home", "Landing Page")
+   - Extract the Screen ID from the screen's `name` field
+
+4. **Metadata fetch**: 
+   - Call `[prefix]:get_screen` with both `projectId` and `screenId` (both as numeric IDs only)
+   - This returns the complete screen object including:
+     - `screenshot.downloadUrl` - Visual reference of the design
+     - `htmlCode.downloadUrl` - Full HTML/CSS source code
+     - `width`, `height`, `deviceType` - Screen dimensions and target platform
+     - Project metadata including `designTheme` with color and style information
+
+5. **Asset download**:
+   - Use `web_fetch` or `read_url_content` to download the HTML code from `htmlCode.downloadUrl`
+   - Optionally download the screenshot from `screenshot.downloadUrl` for visual reference
+   - Parse the HTML to extract Tailwind classes, custom CSS, and component patterns
+
+6. **Project metadata extraction**:
+   - Call `[prefix]:get_project` with the project `name` (full path: `projects/{id}`) to get:
+     - `designTheme` object with color mode, fonts, roundness, custom colors
+     - Project-level design guidelines and descriptions
+     - Device type preferences and layout principles
+
+## Analysis & Synthesis Instructions
+
+### 1. Extract Project Identity (JSON)
+- Locate the Project Title
+- Locate the specific Project ID (e.g., from the `name` field in the JSON)
+
+### 2. Define the Atmosphere (Image/HTML)
+Evaluate the screenshot and HTML structure to capture the overall "vibe." Use evocative adjectives to describe the mood (e.g., "Airy," "Dense," "Minimalist," "Utilitarian").
+
+### 3. Map the Color Palette (Tailwind Config/JSON)
+Identify the key colors in the system. For each color, provide:
+- A descriptive, natural language name that conveys its character (e.g., "Deep Muted Teal-Navy")
+- The specific hex code in parentheses for precision (e.g., "#294056")
+- Its specific functional role (e.g., "Used for primary actions")
+
+### 4. Translate Geometry & Shape (CSS/Tailwind)
+Convert technical `border-radius` and layout values into physical descriptions:
+- Describe `rounded-full` as "Pill-shaped"
+- Describe `rounded-lg` as "Subtly rounded corners"
+- Describe `rounded-none` as "Sharp, squared-off edges"
+
+### 5. Describe Depth & Elevation
+Explain how the UI handles layers. Describe the presence and quality of shadows (e.g., "Flat," "Whisper-soft diffused shadows," or "Heavy, high-contrast drop shadows").
+
+## Output Guidelines
+
+- **Language:** Use descriptive design terminology and natural language exclusively
+- **Format:** Generate a clean Markdown file following the structure below
+- **Precision:** Include exact hex codes for colors while using descriptive names
+- **Context:** Explain the "why" behind design decisions, not just the "what"
+
+## Output Format (DESIGN.md Structure)
+
+```markdown
+# Design System: [Project Title]
+**Project ID:** [Insert Project ID Here]
+
+## 1. Visual Theme & Atmosphere
+(Description of the mood, density, and aesthetic philosophy.)
+
+## 2. Color Palette & Roles
+(List colors by Descriptive Name + Hex Code + Functional Role.)
+
+## 3. Typography Rules
+(Description of font family, weight usage for headers vs. body, and letter-spacing character.)
+
+## 4. Component Stylings
+* **Buttons:** (Shape description, color assignment, behavior).
+* **Cards/Containers:** (Corner roundness description, background color, shadow depth).
+* **Inputs/Forms:** (Stroke style, background).
+
+## 5. Layout Principles
+(Description of whitespace strategy, margins, and grid alignment.)
+```
+
+## Usage Example
+
+To use this skill for the Furniture Collection project:
+
+1. **Retrieve project information:**
+   ```
+   Use the Stitch MCP Server to get the Furniture Collection project
+   ```
+
+2. **Get the Home page screen details:**
+   ```
+   Retrieve the Home page screen's code, image, and screen object information
+   ```
+
+3. **Reference best practices:**
+   ```
+   Review the Stitch Effective Prompting Guide at:
+   https://stitch.withgoogle.com/docs/learn/prompting/
+   ```
+
+4. **Analyze and synthesize:**
+   - Extract all relevant design tokens from the screen
+   - Translate technical values into descriptive language
+   - Organize information according to the DESIGN.md structure
+
+5. **Generate the file:**
+   - Create `DESIGN.md` in the project directory
+   - Follow the prescribed format exactly
+   - Ensure all color codes are accurate
+   - Use evocative, designer-friendly language
+
+## Best Practices
+
+- **Be Descriptive:** Avoid generic terms like "blue" or "rounded." Use "Ocean-deep Cerulean (#0077B6)" or "Gently curved edges"
+- **Be Functional:** Always explain what each design element is used for
+- **Be Consistent:** Use the same terminology throughout the document
+- **Be Visual:** Help readers visualize the design through your descriptions
+- **Be Precise:** Include exact values (hex codes, pixel values) in parentheses after natural language descriptions
+
+## Tips for Success
+
+1. **Start with the big picture:** Understand the overall aesthetic before diving into details
+2. **Look for patterns:** Identify consistent spacing, sizing, and styling patterns
+3. **Think semantically:** Name colors by their purpose, not just their appearance
+4. **Consider hierarchy:** Document how visual weight and importance are communicated
+5. **Reference the guide:** Use language and patterns from the Stitch Effective Prompting Guide
+
+## Common Pitfalls to Avoid
+
+- ❌ Using technical jargon without translation (e.g., "rounded-xl" instead of "generously rounded corners")
+- ❌ Omitting color codes or using only descriptive names
+- ❌ Forgetting to explain functional roles of design elements
+- ❌ Being too vague in atmosphere descriptions
+- ❌ Ignoring subtle design details like shadows or spacing patterns

--- a/.agents/skills/design-md/examples/DESIGN.md
+++ b/.agents/skills/design-md/examples/DESIGN.md
@@ -1,0 +1,154 @@
+# Design System: Furniture Collections List
+**Project ID:** 13534454087919359824
+
+## 1. Visual Theme & Atmosphere
+
+The Furniture Collections List embodies a **sophisticated, minimalist sanctuary** that marries the pristine simplicity of Scandinavian design with the refined visual language of luxury editorial presentation. The interface feels **spacious and tranquil**, prioritizing breathing room and visual clarity above all else. The design philosophy is gallery-like and photography-first, allowing each furniture piece to command attention as an individual art object.
+
+The overall mood is **airy yet grounded**, creating an aspirational aesthetic that remains approachable and welcoming. The interface feels **utilitarian in its restraint** but elegant in its execution, with every element serving a clear purpose while maintaining visual sophistication. The atmosphere evokes the serene ambiance of a high-end furniture showroom where customers can browse thoughtfully without visual overwhelm.
+
+**Key Characteristics:**
+- Expansive whitespace creating generous breathing room between elements
+- Clean, architectural grid system with structured content blocks
+- Photography-first presentation with minimal UI interference
+- Whisper-soft visual hierarchy that guides without shouting
+- Refined, understated interactive elements
+- Professional yet inviting editorial tone
+
+## 2. Color Palette & Roles
+
+### Primary Foundation
+- **Warm Barely-There Cream** (#FCFAFA) – Primary background color. Creates an almost imperceptible warmth that feels more inviting than pure white, serving as the serene canvas for the entire experience.
+- **Crisp Very Light Gray** (#F5F5F5) – Secondary surface color used for card backgrounds and content areas. Provides subtle visual separation while maintaining the airy, ethereal quality.
+
+### Accent & Interactive
+- **Deep Muted Teal-Navy** (#294056) – The sole vibrant accent in the palette. Used exclusively for primary call-to-action buttons (e.g., "Shop Now", "View all products"), active navigation links, selected filter states, and subtle interaction highlights. This sophisticated anchor color creates visual focus points without disrupting the serene neutral foundation.
+
+### Typography & Text Hierarchy
+- **Charcoal Near-Black** (#2C2C2C) – Primary text color for headlines and product names. Provides strong readable contrast while being softer and more refined than pure black.
+- **Soft Warm Gray** (#6B6B6B) – Secondary text used for body copy, product descriptions, and supporting metadata. Creates clear typographic hierarchy without harsh contrast.
+- **Ultra-Soft Silver Gray** (#E0E0E0) – Tertiary color for borders, dividers, and subtle structural elements. Creates separation so gentle it's almost imperceptible.
+
+### Functional States (Reserved for system feedback)
+- **Success Moss** (#10B981) – Stock availability, confirmation states, positive indicators
+- **Alert Terracotta** (#EF4444) – Low stock warnings, error states, critical alerts
+- **Informational Slate** (#64748B) – Neutral system messages, informational callouts
+
+## 3. Typography Rules
+
+**Primary Font Family:** Manrope  
+**Character:** Modern, geometric sans-serif with gentle humanist warmth. Slightly rounded letterforms that feel contemporary yet approachable.
+
+### Hierarchy & Weights
+- **Display Headlines (H1):** Semi-bold weight (600), generous letter-spacing (0.02em for elegance), 2.75-3.5rem size. Used sparingly for hero sections and major page titles.
+- **Section Headers (H2):** Semi-bold weight (600), subtle letter-spacing (0.01em), 2-2.5rem size. Establishes clear content zones and featured collections.
+- **Subsection Headers (H3):** Medium weight (500), normal letter-spacing, 1.5-1.75rem size. Product names and category labels.
+- **Body Text:** Regular weight (400), relaxed line-height (1.7), 1rem size. Descriptions and supporting content prioritize comfortable readability.
+- **Small Text/Meta:** Regular weight (400), slightly tighter line-height (1.5), 0.875rem size. Prices, availability, and metadata remain legible but visually recessive.
+- **CTA Buttons:** Medium weight (500), subtle letter-spacing (0.01em), 1rem size. Balanced presence without visual aggression.
+
+### Spacing Principles
+- Headers use slightly expanded letter-spacing for refined elegance
+- Body text maintains generous line-height (1.7) for effortless reading
+- Consistent vertical rhythm with 2-3rem between related text blocks
+- Large margins (4-6rem) between major sections to reinforce spaciousness
+
+## 4. Component Stylings
+
+### Buttons
+- **Shape:** Subtly rounded corners (8px/0.5rem radius) – approachable and modern without appearing playful or childish
+- **Primary CTA:** Deep Muted Teal-Navy (#294056) background with pure white text, comfortable padding (0.875rem vertical, 2rem horizontal)
+- **Hover State:** Subtle darkening to deeper navy, smooth 250ms ease-in-out transition
+- **Focus State:** Soft outer glow in the primary color for keyboard navigation accessibility
+- **Secondary CTA (if needed):** Outlined style with Deep Muted Teal-Navy border, transparent background, hover fills with whisper-soft teal tint
+
+### Cards & Product Containers
+- **Corner Style:** Gently rounded corners (12px/0.75rem radius) creating soft, refined edges
+- **Background:** Alternates between Warm Barely-There Cream and Crisp Very Light Gray based on layering needs
+- **Shadow Strategy:** Flat by default. On hover, whisper-soft diffused shadow appears (`0 2px 8px rgba(0,0,0,0.06)`) creating subtle depth
+- **Border:** Optional hairline border (1px) in Ultra-Soft Silver Gray for delicate definition when shadows aren't present
+- **Internal Padding:** Generous 2-2.5rem creating comfortable breathing room for content
+- **Image Treatment:** Full-bleed at the top of cards, square or 4:3 ratio, seamless edge-to-edge presentation
+
+### Navigation
+- **Style:** Clean horizontal layout with generous spacing (2-3rem) between menu items
+- **Typography:** Medium weight (500), subtle uppercase, expanded letter-spacing (0.06em) for refined sophistication
+- **Default State:** Charcoal Near-Black text
+- **Active/Hover State:** Smooth 200ms color transition to Deep Muted Teal-Navy
+- **Active Indicator:** Thin underline (2px) in Deep Muted Teal-Navy appearing below current section
+- **Mobile:** Converts to elegant hamburger menu with sliding drawer
+
+### Inputs & Forms
+- **Stroke Style:** Refined 1px border in Soft Warm Gray
+- **Background:** Warm Barely-There Cream with transition to Crisp Very Light Gray on focus
+- **Corner Style:** Matching button roundness (8px/0.5rem) for visual consistency
+- **Focus State:** Border color shifts to Deep Muted Teal-Navy with subtle outer glow
+- **Padding:** Comfortable 0.875rem vertical, 1.25rem horizontal for touch-friendly targets
+- **Placeholder Text:** Ultra-Soft Silver Gray, elegant and unobtrusive
+
+### Product Cards (Specific Pattern)
+- **Image Area:** Square (1:1) or landscape (4:3) ratio filling card width completely
+- **Content Stack:** Product name (H3), brief descriptor, material/finish, price
+- **Price Display:** Emphasized with semi-bold weight (600) in Charcoal Near-Black
+- **Hover Behavior:** Gentle lift effect (translateY -4px) combined with enhanced shadow
+- **Spacing:** Consistent 1.5rem internal padding below image
+
+## 5. Layout Principles
+
+### Grid & Structure
+- **Max Content Width:** 1440px for optimal readability and visual balance on large displays
+- **Grid System:** Responsive 12-column grid with fluid gutters (24px mobile, 32px desktop)
+- **Product Grid:** 4 columns on large desktop, 3 on desktop, 2 on tablet, 1 on mobile
+- **Breakpoints:** 
+  - Mobile: <768px
+  - Tablet: 768-1024px  
+  - Desktop: 1024-1440px
+  - Large Desktop: >1440px
+
+### Whitespace Strategy (Critical to the Design)
+- **Base Unit:** 8px for micro-spacing, 16px for component spacing
+- **Vertical Rhythm:** Consistent 2rem (32px) base unit between related elements
+- **Section Margins:** Generous 5-8rem (80-128px) between major sections creating dramatic breathing room
+- **Edge Padding:** 1.5rem (24px) mobile, 3rem (48px) tablet/desktop for comfortable framing
+- **Hero Sections:** Extra-generous top/bottom padding (8-12rem) for impactful presentation
+
+### Alignment & Visual Balance
+- **Text Alignment:** Left-aligned for body and navigation (optimal readability), centered for hero headlines and featured content
+- **Image to Text Ratio:** Heavily weighted toward imagery (70-30 split) reinforcing photography-first philosophy
+- **Asymmetric Balance:** Large hero images offset by compact, refined text blocks
+- **Visual Weight Distribution:** Strategic use of whitespace to draw eyes to hero products and primary CTAs
+- **Reading Flow:** Clear top-to-bottom, left-to-right pattern with intentional focal points
+
+### Responsive Behavior & Touch
+- **Mobile-First Foundation:** Core experience designed and perfected for smallest screens first
+- **Progressive Enhancement:** Additional columns, imagery, and details added gracefully at larger breakpoints
+- **Touch Targets:** Minimum 44x44px for all interactive elements (WCAG AAA compliant)
+- **Image Optimization:** Responsive images with appropriate resolutions for each breakpoint, lazy-loading for performance
+- **Collapsing Strategy:** Navigation collapses to hamburger, grid reduces columns, padding scales proportionally
+
+## 6. Design System Notes for Stitch Generation
+
+When creating new screens for this project using Stitch, reference these specific instructions:
+
+### Language to Use
+- **Atmosphere:** "Sophisticated minimalist sanctuary with gallery-like spaciousness"
+- **Button Shapes:** "Subtly rounded corners" (not "rounded-md" or "8px")
+- **Shadows:** "Whisper-soft diffused shadows on hover" (not "shadow-sm")
+- **Spacing:** "Generous breathing room" and "expansive whitespace"
+
+### Color References
+Always use the descriptive names with hex codes:
+- Primary CTA: "Deep Muted Teal-Navy (#294056)"
+- Backgrounds: "Warm Barely-There Cream (#FCFAFA)" or "Crisp Very Light Gray (#F5F5F5)"
+- Text: "Charcoal Near-Black (#2C2C2C)" or "Soft Warm Gray (#6B6B6B)"
+
+### Component Prompts
+- "Create a product card with gently rounded corners, full-bleed square product image, and whisper-soft shadow on hover"
+- "Design a primary call-to-action button in Deep Muted Teal-Navy (#294056) with subtle rounded corners and comfortable padding"
+- "Add a navigation bar with generous spacing between items, using medium-weight Manrope with subtle uppercase and expanded letter-spacing"
+
+### Incremental Iteration
+When refining existing screens:
+1. Focus on ONE component at a time (e.g., "Update the product grid cards")
+2. Be specific about what to change (e.g., "Increase the internal padding of product cards from 1.5rem to 2rem")
+3. Reference this design system language consistently

--- a/.claude/skills/design-md
+++ b/.claude/skills/design-md
@@ -1,0 +1,1 @@
+../../.agents/skills/design-md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ The product overview (what llame is) is short and always relevant, so it is impo
 - [SPEC.md](SPEC.md) — full product & architecture specification
 - [ROADMAP.md](ROADMAP.md) — planned milestones (forward-looking)
 - [CHANGELOG.md](CHANGELOG.md) — shipped history
+- [DESIGN.md](DESIGN.md) — design system reference (visual language, OKLCH tokens, component stylings); consult before building or restyling any UI
 
 ## Monorepo layout
 
@@ -56,6 +57,7 @@ Dev provisions a non-superuser role so RLS (incl. `FORCE`) is exercised as in pr
 - TypeScript only across web/api/worker — no second backend language (SPEC.md §23).
 - Drizzle ORM for all DB access; generate migrations with `drizzle-kit`, never hand-write migration SQL.
 - Conventional commits (e.g. `feat(api):`, `docs(spec):`).
+- UI work follows the design language in [DESIGN.md](DESIGN.md) — compose `@workspace/ui` primitives and the semantic tokens; no ad-hoc colors or a brand hue (see its §10 Do/Don't).
 
 ## Security
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,223 @@
+# Design System: llame
+> A monochrome control room for an AI operating layer — quiet surfaces, ink-on-paper text, and a single restrained accent reserved for danger.
+
+**Status:** Living document. Describes the design language as it exists in `packages/ui` (shared shadcn/ui kit) and `apps/web` today. The system is currently a **disciplined neutral minimalism** built on shadcn's `new-york` style with a `neutral` base — intentional restraint, not an unfinished theme. See [§12 Open Decisions](#12-open-decisions) for what is deliberately not yet decided.
+
+---
+
+## 0. How to use this file
+
+This is the source-of-truth brief for anyone — human or AI coding agent — generating or restyling a llame screen. It captures the *why* and the *feel* in natural language, backed by exact tokens.
+
+- **Building a new screen or component?** Read §1–§2 for the mood, then pull concrete values from §3–§9.
+- **Prompting an AI agent (Claude, Cursor, etc.) to generate UI?** Paste §1–§2 and the relevant component section, then point it at the real primitives in `packages/ui/src/components`. The agent should *compose* those primitives, not re-style them.
+- **The authoritative token values live in `packages/ui/src/styles/globals.css`.** When this file and the CSS disagree, the CSS wins — update this file.
+- Hex codes below are sRGB **approximations** of the authoritative **OKLCH** values; OKLCH is what ships.
+
+---
+
+## 1. Visual Theme & Atmosphere
+
+llame looks like a well-lit, near-silent workshop. The interface is almost entirely **achromatic** — a grayscale stack from pure white through ash to near-black — so that the user's content (chats, knowledge, artifacts) is the only thing carrying color and weight. There is **no brand hue**, no gradient field, no decorative imagery. Separation between regions comes from subtle value shifts (white canvas against a faintly cooler off-white rail) and thin hairline borders, not from heavy shadows or chrome.
+
+The mood is **calm, dense-but-uncluttered, and utilitarian**. Corners are softly rounded (10px), elevation is whisper-flat, and typography does most of the expressive work. The one chromatic note in the entire system is a saturated red reserved exclusively for destructive intent — its rarity is what makes it legible. Color is present in exactly two governed places: **data visualization** (the chart ramp) and **danger** (destructive). Everything else is ink and paper.
+
+Full dark mode is a first-class peer, not an afterthought: the same semantic roles invert into a charcoal canvas with off-white ink.
+
+**Adjectives:** monochrome · airy · disciplined · platform-native · quiet · content-first.
+
+---
+
+## 2. Color Palette & Roles
+
+The palette is Tailwind's **neutral** ramp expressed in OKLCH, addressed through semantic CSS variables (never raw hex in components). Below, each role gets an evocative name, the authoritative OKLCH, an approximate hex, and its job.
+
+### 2.1 Light mode (`:root`)
+
+| Name       | OKLCH (authoritative)       | ~Hex      | Token(s)                              | Role                                                                                         |
+| ---------- | --------------------------- | --------- | ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Pure White | `oklch(1 0 0)`              | `#ffffff` | `--background`, `--card`, `--popover` | Main canvas, card and popover surfaces — where attention belongs                             |
+| Bone       | `oklch(0.985 0 0)`          | `#fafafa` | `--sidebar`, `--primary-foreground`   | The slightly cooler off-white of the navigation rail; also text on dark fills                |
+| Mist       | `oklch(0.97 0 0)`           | `#f5f5f5` | `--secondary`, `--muted`, `--accent`  | Quiet fills for secondary buttons, muted blocks, hover/active surfaces                       |
+| Hairline   | `oklch(0.922 0 0)`          | `#e5e5e5` | `--border`, `--input`                 | The thin 1px lines that separate regions and outline inputs                                  |
+| Pewter     | `oklch(0.708 0 0)`          | `#a1a1a1` | `--ring`                              | Focus ring base (rendered at ~50% opacity)                                                   |
+| Slate      | `oklch(0.556 0 0)`          | `#737373` | `--muted-foreground`                  | Secondary/helper text, placeholders, captions, inactive icons                                |
+| Ink        | `oklch(0.205 0 0)`          | `#171717` | `--primary`                           | Primary action fill, the strongest interactive surface in light mode                         |
+| Near-Black | `oklch(0.145 0 0)`          | `#0a0a0a` | `--foreground`, `--card-foreground`   | Body text, headings, icons — the default ink                                                 |
+| Alert Red  | `oklch(0.577 0.245 27.325)` | `#e7000b` | `--destructive`                       | The system's **only** standing chromatic color — destructive actions and invalid states only |
+
+### 2.2 Dark mode (`.dark`)
+
+Roles invert; the canvas becomes charcoal and ink becomes off-white. Key shifts:
+
+| Token                                                       | OKLCH                        | ~Hex      | Role in dark                                                                     |
+| ----------------------------------------------------------- | ---------------------------- | --------- | -------------------------------------------------------------------------------- |
+| `--background`, `--card`, `--popover`                       | `oklch(0.145 0 0)`           | `#0a0a0a` | Charcoal canvas and surfaces                                                     |
+| `--foreground`                                              | `oklch(0.985 0 0)`           | `#fafafa` | Off-white ink                                                                    |
+| `--primary`                                                 | `oklch(0.985 0 0)`           | `#fafafa` | Primary fill is now near-white (with charcoal text)                              |
+| `--secondary`, `--muted`, `--accent`, `--border`, `--input` | `oklch(0.269 0 0)`           | `#262626` | Graphite quiet surfaces and lines                                                |
+| `--muted-foreground`, `--ring`                              | `oklch(0.708 0 0)` / `0.556` | `#a1a1a1` | Dimmed text and focus ring                                                       |
+| `--destructive`                                             | `oklch(0.396 0.141 25.723)`  | `#82181a` | Deeper red fill; foreground brightens to `oklch(0.637 0.237 25.331)` ≈ `#fb2c36` |
+| `--sidebar`                                                 | `oklch(0.205 0 0)`           | `#171717` | Rail sits one step above the charcoal canvas                                     |
+
+### 2.3 Chart ramp — the sanctioned chromatic exception
+
+`--chart-1` … `--chart-5` are the **only** place broad color is allowed, and only inside data visualization. They are a warm-to-cool spread (light: burnt orange, teal, deep slate-blue, gold, amber), retuned for contrast in dark mode (a blue/green/violet/rose spread). Do not borrow chart colors for UI accents, branding, or CTAs.
+
+---
+
+## 3. Typography
+
+Typography is the system's primary expressive instrument — and it is **user-configurable by design**, an accessibility and personalization feature rather than a fixed brand face.
+
+- **Two semantic faces:** `--font-sans` (UI + prose) and `--font-mono` (code, technical strings). Components only ever reference these two variables.
+- **Resolution:** the active face is resolved at request time by the web appearance service (`apps/web/lib/appearance/font/service.ts` → `getFontCssVariables()`), which writes `--font-sans` / `--font-mono` into `:root`. `body` applies `font-sans antialiased`.
+- **Defaults:** sans defaults to the **system stack** (`system-ui, -apple-system, …`) for instant, platform-native rendering; mono defaults to **JetBrains Mono**.
+- **Selectable sans faces:** Geist, Open Sans, Roboto, Roboto Condensed, and **OpenDyslexic** (a genuine accessibility option — see §6). **Selectable mono faces:** Geist Mono, JetBrains Mono, Fira Code, Roboto Mono, OpenDyslexic Mono. All are loaded as `next/font` CSS variables in `apps/web/app/layout.tsx`.
+
+### Weight & scale character
+
+- **Weights stay conversational.** UI text is `font-medium` (500) for controls and labels, `font-semibold` (600) for card/section titles; body is regular. The system avoids display-weight boldness — emphasis comes from value contrast (Ink vs Slate) and weight ≤ 600, not heavy type.
+- **Sizes follow shadcn defaults:** controls and body at `text-sm` (14px) on desktop, inputs at `text-base` (16px) on mobile collapsing to `text-sm` at `md` (prevents iOS zoom-on-focus); inline code and code blocks at ~13px mono.
+- **Icons:** Lucide, default `size-4` (16px), inheriting `currentColor` so they read as text-weight ink.
+
+---
+
+## 4. Geometry & Shape
+
+One radius scale, derived from a single `--radius: 0.625rem` (**10px**) root. Corners are **softly rounded, never pill-shaped, never sharp** — the system has no fully-square and no fully-round (`9999px`) elements in its primitives.
+
+| Token         | Value                             | Feel                         | Used by                                   |
+| ------------- | --------------------------------- | ---------------------------- | ----------------------------------------- |
+| `--radius-sm` | `calc(--radius - 4px)` = **6px**  | Gently eased                 | Inline code (`rounded-sm`), small chips   |
+| `--radius-md` | `calc(--radius - 2px)` = **8px**  | Subtly rounded               | Buttons, inputs, textareas (`rounded-md`) |
+| `--radius-lg` | `--radius` = **10px**             | The system's signature curve | Default container radius                  |
+| `--radius-xl` | `calc(--radius + 4px)` = **14px** | Generously rounded           | Cards and code blocks (`rounded-xl`)      |
+
+---
+
+## 5. Depth & Elevation
+
+Elevation is **whisper-flat**. The system separates layers primarily through hairline borders and value shifts, with shadows used only as the faintest hint of lift.
+
+- **Inputs, textareas, buttons:** `shadow-xs` — a barely-perceptible drop, almost flush with the surface.
+- **Cards, code blocks:** `shadow-sm` + a 1px border — the heaviest elevation in the system, and still subtle.
+- **Popovers, dialogs, dropdowns, sheets:** rely on the component primitives' own light shadow plus a border; never heavy, high-contrast drop shadows.
+- **Region separation** (rail vs. canvas, header vs. content) is done with **borders and the Bone→White value shift**, not shadows.
+
+Rule of thumb: if a surface needs to feel "above" another, add a **border first**, a `shadow-sm` second, and never reach past it.
+
+---
+
+## 6. Accessibility (first-class)
+
+Accessibility is a design value here, not a remediation pass:
+
+- **Dyslexia-friendly typography** is a shipped option — `OpenDyslexic` / `OpenDyslexic Mono` are wired into the font appearance system alongside the standard faces, switchable per user.
+- **Visible, generous focus.** Interactive primitives use `focus-visible:ring-[3px]` with `--ring` at ~50% opacity plus a `border-ring` shift — a deliberately thick, unmissable focus indicator, not a hairline.
+- **Validation is communicated, not just colored.** `aria-invalid` triggers a destructive ring + border (`aria-invalid:ring-destructive/20 dark:…/40 aria-invalid:border-destructive`), pairing the red with the ARIA state rather than relying on hue alone.
+- **Full light/dark parity** via semantic tokens, so contrast holds in both modes.
+- **Platform-native defaults** (system font stack, `antialiased`) keep text crisp and familiar before any customization.
+
+---
+
+## 7. Motion
+
+Motion is **purposeful and sparse**, powered by `framer-motion` (imported as `motion/react`) and `tw-animate-css`:
+
+- **`TextShimmer`** (`text-shimmer.tsx`) is the signature AI-state animation: a horizontal gradient sweeps across text on an infinite linear loop to signal "thinking"/streaming. Base color `#a1a1aa` light / `#71717a` dark with an ink/white highlight — monochrome, in keeping with the palette.
+- **`transition-all` / `transition-[color,box-shadow]`** on controls give quiet hover and focus easing, not bouncy or attention-grabbing motion.
+- Keep motion legible and short; reserve looping animation for genuine progress/streaming states.
+
+---
+
+## 8. Component Stylings
+
+All values below are read from the real primitives in `packages/ui/src/components`. Compose these — do not re-skin them in app code.
+
+### Buttons (`button.tsx`)
+- **Shape & type:** `rounded-md` (8px), `text-sm font-medium`, `gap-2`, `shadow-xs`, `transition-all`.
+- **Sizes:** `default` h-9 (`px-4`), `sm` h-8, `lg` h-10 (`px-6`), `icon` size-9. SVG icons auto-sized to `size-4`.
+- **Variants:** `default` (Ink/`bg-primary` fill, Bone text) · `secondary` (Mist fill) · `outline` (border + transparent, `hover:bg-accent`) · `ghost` (no fill until `hover:bg-accent`) · `destructive` (Alert Red fill, white text) · `link` (underline-on-hover, no fill).
+- **States:** focus → `ring-[3px]` + `border-ring`; disabled → `opacity-50`, no pointer events; invalid → destructive ring.
+
+### Inputs & Textareas (`input.tsx`, `textarea.tsx`)
+- **Stroke style:** 1px `border-input` hairline on a **transparent** background (light) / `bg-input/30` (dark) — outlined, not filled.
+- **Shape:** `rounded-md` (8px), `shadow-xs`, `px-3`. Input `h-9`; textarea `min-h-16` with `field-sizing-content` (auto-grow).
+- **Type:** `text-base` (mobile) → `text-sm` at `md`; placeholders in Slate (`text-muted-foreground`).
+- **States:** focus → thick `ring-[3px]` + `border-ring`; `aria-invalid` → destructive ring + border; text selection uses `bg-primary`/`text-primary-foreground`.
+
+### Cards (`card.tsx`)
+- **Container:** `bg-card` surface, 1px border, `rounded-xl` (14px — the system's most generous curve), `shadow-sm`, vertical rhythm `py-6` + `gap-6`, horizontal padding `px-6`.
+- **Anatomy:** `CardHeader` (grid, supports a right-aligned `CardAction`), `CardTitle` (`font-semibold`, tight leading), `CardDescription` (Slate, `text-sm`), `CardContent`, `CardFooter`.
+
+### Code blocks & Markdown (`code-block.tsx`, `markdown.tsx`)
+- **Code block:** `bg-card`, 1px `border-border`, `rounded-xl`, `overflow-clip`, code at `text-[13px]` with `px-4 py-4`. Syntax highlighting via **Shiki** (`github-light` theme default), with a plain-`<pre>` SSR fallback before hydration.
+- **Markdown renderer:** `react-markdown` + `remark-gfm` + `remark-breaks`, parsed block-by-block and memoized for streaming performance. Inline code renders on a `bg-primary-foreground` chip, `rounded-sm` (6px), `font-mono text-sm`; fenced blocks route into the Code block component.
+
+### Sidebar / Navigation (`sidebar.tsx`)
+- **Surface:** dedicated `--sidebar` token family (rail sits on Bone in light, one step above charcoal in dark) with `--sidebar-border` hairlines and `--sidebar-accent` hover/active fills.
+- **Dimensions:** `16rem` (256px) expanded, collapses to `3rem` (48px) icon-rail, `18rem` on mobile (off-canvas sheet).
+- **Active/hover state** is a background fill shift (`hover:bg-sidebar-accent`), not a colored left-border or accent bar — consistent with the no-chrome philosophy.
+
+### Overlays
+Dialog, Popover, Dropdown menu, Sheet, Tooltip, Command (⌘K palette), Sonner (toasts) — all use the `--popover` surface, hairline borders, the shared radius scale, and the kit's light shadow. Keep overlays on these primitives rather than hand-rolling.
+
+---
+
+## 9. Layout Principles
+
+- **Two-zone shell:** a persistent left rail (navigation, account) against a wide content stage, separated by value + border, not shadow.
+- **Whitespace is structural.** Lean on the card's `gap-6`/`py-6` rhythm and generous container padding; let negative space, not dividers, group content.
+- **Content-first centering.** Give primary reading/chat columns room to breathe; the canvas is a stage, the UI a frame.
+- **Density is compact but never cramped** — controls cluster at `gap-2`, sections breathe at `gap-6`.
+- **Responsive type guard:** inputs render at 16px on mobile to avoid iOS zoom, tightening to 14px on desktop.
+
+---
+
+## 10. Guidelines — Do
+
+- Use the **semantic tokens** (`bg-primary`, `text-muted-foreground`, `border-input`, …) — never raw hex or one-off OKLCH in components.
+- Keep the interface **achromatic**; let user content and the chart ramp carry color.
+- Reserve **Alert Red strictly for destructive actions and invalid states** — its scarcity is its signal.
+- Stay on the **10px-derived radius scale**: `rounded-md` for controls, `rounded-xl` for cards/code.
+- Separate regions with **borders and value shifts first**, a faint `shadow-sm` at most.
+- Cap weight at **600**; create emphasis through Ink↔Slate value contrast, not heavy type.
+- Compose the **existing `@workspace/ui` primitives**; add variants via `cva`, not by re-skinning.
+- Honor the **font appearance system** — reference `--font-sans` / `--font-mono`, never hardcode a face.
+- Give every interactive element a **visible `ring-[3px]` focus state**.
+
+## 10b. Guidelines — Don't
+
+- **Don't introduce a brand hue, gradient, or accent color** — monochrome is the signature, not a gap to fill (until §12 is resolved deliberately).
+- **Don't use heavy or high-contrast drop shadows** for elevation.
+- **Don't use pill (`rounded-full`) or sharp (`rounded-none`) shapes** for buttons, inputs, or containers.
+- **Don't repurpose chart colors** (`--chart-*`) as UI accents or branding.
+- **Don't reach for display weights (700–900)** in UI chrome.
+- **Don't hardcode font families** or bypass the appearance service.
+- **Don't communicate validity by color alone** — pair it with `aria-invalid` state.
+- **Don't fork generated shadcn primitives** casually; prefer composition (see `packages/ui/CLAUDE.md`).
+
+---
+
+## 11. Token Reference (quick map)
+
+| Concern                    | Source of truth                                                                                |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| Colors, radius, theme      | `packages/ui/src/styles/globals.css` (`:root`, `.dark`, `@theme inline`)                       |
+| shadcn config              | `packages/ui/components.json` (`style: new-york`, `baseColor: neutral`, `iconLibrary: lucide`) |
+| Component primitives       | `packages/ui/src/components/*`                                                                 |
+| Font loading               | `apps/web/app/layout.tsx`                                                                      |
+| Font resolution / defaults | `apps/web/lib/appearance/font/{consts,service}.ts`                                             |
+
+---
+
+## 12. Open Decisions
+
+These are **intentionally undecided**, flagged so they're chosen deliberately rather than by drift:
+
+1. **No brand/primary hue.** Today "primary" is Ink (near-black). Whether llame ever adopts a chromatic brand accent — and where it would be allowed without breaking the monochrome discipline — is an open product/brand decision, not an oversight.
+2. **Stock-shadcn baseline.** The token set is essentially shadcn's `new-york`/`neutral` defaults. That's a fast, coherent starting point; any move toward a more bespoke identity (custom ramp, custom radius, motion language) should be a conscious step documented here.
+3. **Density profile.** The kit ships shadcn's default sizing. A denser "pro" mode (smaller controls, tighter rhythm) for power-user surfaces is unexplored.
+
+When any of these is decided, update this file in the same change.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,6 +6,12 @@
       "sourceType": "github",
       "skillPath": "SKILL.md",
       "computedHash": "3adbf28218bfda79003844f4bc580c4314230294234d2aeb9941042c3dda5c89"
+    },
+    "design-md": {
+      "source": "google-labs-code/stitch-skills",
+      "sourceType": "github",
+      "skillPath": "plugins/stitch-utilities/skills/design-md/SKILL.md",
+      "computedHash": "44af3e6e89a42a765d9cebf943f1e2ff3cdf43d1958341eb43fb7b74116f6691"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `DESIGN.md` at the repo root — a semantic design-system reference that documents llame's visual language as it exists today in `packages/ui` (shadcn `new-york` / `neutral` base) and `apps/web`, written as a source-of-truth brief for both humans and AI coding agents generating or restyling screens.

Format follows the richer "DESIGN.md" pattern (à la Refero's style references): evocative atmosphere + exact tokens + Do/Don't guidelines, rather than a bare token dump.

## What's inside

- **Atmosphere** — disciplined monochrome minimalism; framed as an intentional stance, not an unfinished theme.
- **Color palette & roles** — the OKLCH neutral ramp with semantic tokens, light + dark, plus the two sanctioned chromatic exceptions (chart ramp, destructive). Hex labeled as sRGB approximations of the authoritative OKLCH.
- **Typography** — the user-switchable font appearance system (default sans = system stack, default mono = JetBrains Mono, OpenDyslexic shipped), resolved via `getFontCssVariables()`.
- **Geometry, elevation, motion** — the 10px-derived radius scale, whisper-flat elevation, sparse purposeful motion (`TextShimmer`).
- **Accessibility** as a first-class section (thick `ring-[3px]` focus, `aria-invalid` pairing, dyslexia-friendly fonts).
- **Component stylings** — read from the real primitives (`button`, `input`, `textarea`, `card`, `code-block`, `markdown`, `sidebar`).
- **Layout principles**, **Do/Don't guidelines**, a **token reference map**, and an **Open Decisions** section flagging deliberately-undecided items (no brand hue, stock-shadcn baseline, no density profile).

## Notes

- Documentation only — no code or token changes.
- Honest finding: the current system is close to stock shadcn `neutral`. The doc says so explicitly and routes the "do we want a bespoke brand identity?" question into §12 Open Decisions rather than inventing one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a root-level `DESIGN.md` that documents our semantic, monochrome design system for `packages/ui` and `apps/web`, plus a Stitch skill to generate `DESIGN.md`. Also links it in `AGENTS.md` so contributors follow it for UI work; docs-only with no runtime or token changes.

- New Features
  - `DESIGN.md`: atmosphere; OKLCH neutral palette with roles (light/dark); user-switchable fonts via `getFontCssVariables()`; 10px radius scale; whisper-flat elevation; minimal motion (`TextShimmer`); accessibility (3px focus ring, `aria-invalid`); component styles (button, input, textarea, card, code-block/markdown, sidebar); layout principles; Do/Don’t; token map; open decisions.
  - Stitch skill at `.agents/skills/design-md` (`SKILL.md`, `README.md`, example): uses Stitch MCP (`list_projects`, `list_screens`, `get_project`, `get_screen`) and `web_fetch` to synthesize `DESIGN.md`; adds `.claude/skills/design-md` link.
  - `AGENTS.md`: adds `DESIGN.md` to Key docs and a convention to follow it for UI work.

- Dependencies
  - Updates `skills-lock.json` to add `design-md` from `google-labs-code/stitch-skills`.

<sup>Written for commit b9dced6522c4d05a5a420580506bb742045c66eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new design-system documentation skill and example output for generating consistent `DESIGN.md` guidance.
  * Introduced a project-wide design reference covering visual language, typography, spacing, motion, and accessibility expectations.

* **Documentation**
  * Updated contributor guidance to point UI work toward the shared design system and approved UI primitives.
  * Added setup and usage instructions for the new design documentation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->