### PR TITLE
chore(docker): pin postgres image by digest

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,9 @@
 
 services:
   postgres:
-    image: postgres:17-alpine
+    # Pinned by digest for reproducibility (dev == prod, single image — no overrides).
+    # Refresh: docker pull postgres:17-alpine && docker inspect --format '{{index .RepoDigests 0}}' postgres:17-alpine
+    image: postgres:17-alpine@sha256:dc17045ccfd343b49600570ea734b9c4991cf1c3f3302e67df51e3b402dd55c4
     container_name: llame-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

Pin the dev Postgres image to its multi-arch index digest:

```yaml
image: postgres:17-alpine@sha256:dc17045ccfd343b49600570ea734b9c4991cf1c3f3302e67df51e3b402dd55c4
```

Reproducible, drift-free boots under the single-image **dev == prod** model. Same image bytes as before — only the reference is locked.

## Why digest pin (and not Docker Hardened Images)

Considered swapping to DHI for supply-chain hardening. Rejected for now:

- **DHI requires `docker login dhi.io` on every machine** — no anonymous pulls, even on the free/Apache-2.0 tier. That tax lands directly on the `git clone && docker compose up` self-host story.
- In a **single-node** deploy, Postgres is on the internal compose network (only the API talks to it) — the lowest-value place to spend hardening.
- A digest pin delivers ~80% of the reproducibility/supply-chain win at **zero friction**.

Revisit DHI if/when there's an internet-exposed or formal prod surface.

## Verification

- `docker compose config` — valid; digest resolves.
- Throwaway fresh-volume boot from the digest → `pg_isready` healthy in 4s.
- `initdb` ran: `app` role created with `rolsuper = f` (non-superuser) — RLS/FORCE tenant-isolation moat intact.
- `postgres:17-alpine` ships a shell, so the existing `CMD-SHELL` healthcheck stays valid (no change needed).

## Out of scope (YAGNI)

- No compose profiles / prod overrides yet — add when topology stops being single-node.
- pgbouncer deferred until multi-instance; when added, base compose + postgres.js `prepare: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned the `postgres:17-alpine` image in `compose.yaml` to a specific digest for reproducible, drift-free boots and dev==prod parity. No behavior change; same image bytes, existing healthcheck remains valid.

<sup>Written for commit 81f0b83aa247066045db168fe238a26215643274. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

