### PR TITLE
docs: changelog for #63 + changelog-in-PR convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ llame is multi-tenant and self-hosted: tenant isolation is a core invariant. Wei
 
 - `ROADMAP.md` is forward-only — it lists work that is **not yet done**.
 - `CHANGELOG.md` is the dated record of everything **shipped** — features, bug fixes, and chores alike — newest first.
-- When work ships: add a dated `CHANGELOG.md` entry, and if it was on the roadmap, remove it from `ROADMAP.md`. Unplanned work (bug fixes, chores) goes straight to the changelog without ever appearing on the roadmap.
+- **Update both in the same PR that ships the work, not after.** The PR's own diff adds the dated `CHANGELOG.md` entry and, if the work was on the roadmap, removes it from `ROADMAP.md` — so the changelog is correct the moment the PR merges, with no separate follow-up commit. Unplanned work (bug fixes, chores) goes straight to the changelog without ever appearing on the roadmap.
 
 ## Current state / gotchas
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ _Reverse-chronological record of shipped work — features, fixes, and chores. N
 
 # 2026-06-30
 
+- Completed the `apps/web` thin-client cutover (#63): removed its database, NextAuth adapter/JWT, and the LangGraph chat/models routes — the browser now calls `apps/api` directly at `NEXT_PUBLIC_API_URL` for `/auth/v1` (login/register/logout) and `/api/v1` (chats + streaming). Layered auth-state (middleware cookie-presence gate → authoritative api guard → client `401` interceptor; `GET /auth/v1/me` as source of truth), with one shared 401 handler across the ky client and the AI SDK chat transport. Added config-driven CORS allowlist + session-cookie `Domain` on `apps/api`.
 - Added the `apps/api` single-model streaming chat loop (#55): guarded `POST /api/v1/chats/:id/messages`, server-authoritative context, idempotent client message ids, AI SDK UI-message SSE streaming, assistant persistence with usage, and abort/cross-tenant/fail-fast e2e coverage.
 
 # 2026-06-29


### PR DESCRIPTION
## Summary
- **CHANGELOG**: record the `apps/web` thin-client cutover (#63), shipped in #75.
- **AGENTS.md**: adopt the standard *changelog-in-the-PR* convention — the CHANGELOG entry (and any ROADMAP removal) rides in the same PR that ships the work, so it lands atomically and there's no post-merge chase commit.

This PR is itself the one-off catch-up for #63 (its feature PR #75 already merged); from now on the entry travels with the feature PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills the changelog for the `apps/web` thin-client cutover (#63, shipped in #75) and adopts a changelog-in-the-PR convention. From now on, each feature PR updates `CHANGELOG.md` (and removes from `ROADMAP.md` when applicable) in the same PR so shipped work lands atomically.

<sup>Written for commit 1231cf551f0223de3e7be61538c827bc3e91d243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

