### PR TITLE
test(e2e): add Playwright auth coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ node_modules
 
 # Testing
 coverage
+playwright-report/
+test-results/
+.auth/
 
 # Turbo
 .turbo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ pnpm test:e2e:report     # playwright show-report
 ```
 
 Scope to one workspace with `pnpm --filter web <script>` (or `--filter api`).
-Install Playwright browsers once with `pnpm exec playwright install chromium` if the local browser cache is missing. For E2E, start/migrate Postgres first (`pnpm db:up && pnpm db:migrate`) or point `POSTGRES_URL` at an already-migrated database; override `E2E_WEB_PORT` and `E2E_API_PORT` only when the default E2E ports (`4300`/`4301`) conflict.
+Install Playwright browsers once with `pnpm exec playwright install chromium` if the local browser cache is missing. For E2E, Playwright starts a throwaway Docker Postgres, applies migrations, then starts `apps/api` and `apps/web`; set `POSTGRES_URL` only to use an already-migrated external database instead. Override `E2E_WEB_PORT`, `E2E_API_PORT`, `E2E_DB_PORT`, or `E2E_DB_READY_PORT` only when the default E2E ports (`4300`/`4301`/`55433`/`4302`) conflict.
 
 ## Local database (docker)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,13 +18,13 @@ The product overview (what llame is) is short and always relevant, so it is impo
 
 pnpm + Turborepo workspace, **TypeScript end-to-end** (Node >= 20, pnpm 10). Workspaces: `apps/*`, `packages/*`.
 
-| Path | Role | Stack (details in its own `AGENTS.md`) |
-|------|------|----------------------------------------|
-| `apps/web` | User-facing **thin client** of `apps/api` (auth, chat/project UI); owns no DB | Next.js 15 (App Router), React 19, TanStack Query, AI SDK (chat transport), ky |
-| `apps/api` | Backend services + **sole database owner**; future home of the durable run worker | NestJS 11, Drizzle + postgres.js |
-| `packages/ui` | Shared shadcn/ui component library (`@workspace/ui`) | shadcn/ui, Tailwind, React 19 |
-| `packages/config-eslint` | Shared ESLint configs (`base`, `next-js`, `react-internal`) | — |
-| `packages/config-typescript` | Shared `tsconfig` bases | — |
+| Path                         | Role                                                                              | Stack (details in its own `AGENTS.md`)                                         |
+| ---------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `apps/web`                   | User-facing **thin client** of `apps/api` (auth, chat/project UI); owns no DB     | Next.js 15 (App Router), React 19, TanStack Query, AI SDK (chat transport), ky |
+| `apps/api`                   | Backend services + **sole database owner**; future home of the durable run worker | NestJS 11, Drizzle + postgres.js                                               |
+| `packages/ui`                | Shared shadcn/ui component library (`@workspace/ui`)                              | shadcn/ui, Tailwind, React 19                                                  |
+| `packages/config-eslint`     | Shared ESLint configs (`base`, `next-js`, `react-internal`)                       | —                                                                              |
+| `packages/config-typescript` | Shared `tsconfig` bases                                                           | —                                                                              |
 
 Each app/package has its own `AGENTS.md` (auto-loaded when you work in that directory) with concrete commands, structure, and gotchas. **Keep this file high-level — put implementation detail in the child file, not here.**
 
@@ -44,7 +44,7 @@ pnpm test:e2e:report     # playwright show-report
 ```
 
 Scope to one workspace with `pnpm --filter web <script>` (or `--filter api`).
-Install Playwright browsers once with `pnpm exec playwright install chromium` if the local browser cache is missing. For E2E, Playwright starts a throwaway Docker Postgres, applies migrations, then starts `apps/api` and `apps/web`; set `POSTGRES_URL` only to use an already-migrated external database instead. Override `E2E_WEB_PORT`, `E2E_API_PORT`, `E2E_DB_PORT`, or `E2E_DB_READY_PORT` only when the default E2E ports (`4300`/`4301`/`55433`/`4302`) conflict.
+Install Playwright browsers once with `pnpm exec playwright install chromium` if the local browser cache is missing. For E2E, Playwright starts a throwaway Docker Postgres, applies migrations, then starts `apps/api` and `apps/web`; set `POSTGRES_URL` only to use an already-migrated external database instead. Authenticated E2E tests should use the worker-scoped fixture from `e2e/fixtures.ts`, which writes per-worker storage state under `.auth/`; destructive session tests should request `freshAccount`. Override `E2E_WEB_PORT`, `E2E_API_PORT`, `E2E_DB_PORT`, or `E2E_DB_READY_PORT` only when the default E2E ports (`4300`/`4301`/`55433`/`4302`) conflict.
 
 ## Local database (docker)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,15 @@ pnpm dev      # turbo dev — all apps in watch mode
 pnpm build    # turbo build
 pnpm lint     # turbo lint
 pnpm format   # prettier --write **/*.{ts,tsx,md}
+pnpm test:e2e            # playwright test; pass filters after --, e.g. pnpm test:e2e -- e2e/auth
+pnpm test:e2e:ui         # playwright test --ui
+pnpm test:e2e:headed     # playwright test --headed
+pnpm test:e2e:debug      # playwright test --debug
+pnpm test:e2e:report     # playwright show-report
 ```
 
 Scope to one workspace with `pnpm --filter web <script>` (or `--filter api`).
+Install Playwright browsers once with `pnpm exec playwright install chromium` if the local browser cache is missing. For E2E, start/migrate Postgres first (`pnpm db:up && pnpm db:migrate`) or point `POSTGRES_URL` at an already-migrated database; override `E2E_WEB_PORT` and `E2E_API_PORT` only when the default E2E ports (`4300`/`4301`) conflict.
 
 ## Local database (docker)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ _Reverse-chronological record of shipped work — features, fixes, and chores. N
 
 # 2026-06-30
 
-- Added Playwright browser E2E coverage for the auth cutover (#79): the Playwright harness starts a throwaway Docker Postgres, applies migrations, starts `apps/api` + `apps/web`, and verifies login success/failure, callback redirect safety, no-cookie redirects, logout, and revoked-session redirect behavior.
+- Added Playwright browser E2E coverage for the auth cutover (#79): the Playwright harness starts a throwaway Docker Postgres, applies migrations, starts `apps/api` + `apps/web`, reuses worker-scoped authenticated storage state, and verifies login success/failure, callback redirect safety, no-cookie redirects, logout, and revoked-session redirect behavior.
 - Completed the `apps/web` thin-client cutover (#63): removed its database, NextAuth adapter/JWT, and the LangGraph chat/models routes — the browser now calls `apps/api` directly at `NEXT_PUBLIC_API_URL` for `/auth/v1` (login/register/logout) and `/api/v1` (chats + streaming). Layered auth-state (middleware cookie-presence gate → authoritative api guard → client `401` interceptor; `GET /auth/v1/me` as source of truth), with one shared 401 handler across the ky client and the AI SDK chat transport. Added config-driven CORS allowlist + session-cookie `Domain` on `apps/api`.
 - Added the `apps/api` single-model streaming chat loop (#55): guarded `POST /api/v1/chats/:id/messages`, server-authoritative context, idempotent client message ids, AI SDK UI-message SSE streaming, assistant persistence with usage, and abort/cross-tenant/fail-fast e2e coverage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ _Reverse-chronological record of shipped work — features, fixes, and chores. N
 
 # 2026-06-30
 
-- Added Playwright browser E2E coverage for the auth cutover (#79): the Playwright harness starts `apps/api` + `apps/web` against a migrated Postgres database and verifies login success/failure, callback redirect safety, no-cookie redirects, logout, and revoked-session redirect behavior.
+- Added Playwright browser E2E coverage for the auth cutover (#79): the Playwright harness starts a throwaway Docker Postgres, applies migrations, starts `apps/api` + `apps/web`, and verifies login success/failure, callback redirect safety, no-cookie redirects, logout, and revoked-session redirect behavior.
 - Completed the `apps/web` thin-client cutover (#63): removed its database, NextAuth adapter/JWT, and the LangGraph chat/models routes — the browser now calls `apps/api` directly at `NEXT_PUBLIC_API_URL` for `/auth/v1` (login/register/logout) and `/api/v1` (chats + streaming). Layered auth-state (middleware cookie-presence gate → authoritative api guard → client `401` interceptor; `GET /auth/v1/me` as source of truth), with one shared 401 handler across the ky client and the AI SDK chat transport. Added config-driven CORS allowlist + session-cookie `Domain` on `apps/api`.
 - Added the `apps/api` single-model streaming chat loop (#55): guarded `POST /api/v1/chats/:id/messages`, server-authoritative context, idempotent client message ids, AI SDK UI-message SSE streaming, assistant persistence with usage, and abort/cross-tenant/fail-fast e2e coverage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ _Reverse-chronological record of shipped work — features, fixes, and chores. N
 
 # 2026-06-30
 
+- Added Playwright browser E2E coverage for the auth cutover (#79): the Playwright harness starts `apps/api` + `apps/web` against a migrated Postgres database and verifies login success/failure, callback redirect safety, no-cookie redirects, logout, and revoked-session redirect behavior.
 - Completed the `apps/web` thin-client cutover (#63): removed its database, NextAuth adapter/JWT, and the LangGraph chat/models routes — the browser now calls `apps/api` directly at `NEXT_PUBLIC_API_URL` for `/auth/v1` (login/register/logout) and `/api/v1` (chats + streaming). Layered auth-state (middleware cookie-presence gate → authoritative api guard → client `401` interceptor; `GET /auth/v1/me` as source of truth), with one shared 401 handler across the ky client and the AI SDK chat transport. Added config-driven CORS allowlist + session-cookie `Domain` on `apps/api`.
 - Added the `apps/api` single-model streaming chat loop (#55): guarded `POST /api/v1/chats/:id/messages`, server-authoritative context, idempotent client message ids, AI SDK UI-message SSE streaming, assistant persistence with usage, and abort/cross-tenant/fail-fast e2e coverage.
 

--- a/e2e/auth/auth.spec.ts
+++ b/e2e/auth/auth.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test";
+import {
+  expectLoginPage,
+  expectProtectedShell,
+  loginViaUi,
+  registerAccount,
+  revokeAllSessions,
+} from "./helpers";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("logs in an existing user", async ({ page, request }) => {
+  const account = await registerAccount(
+    request,
+    "login-success",
+    test.info().parallelIndex,
+  );
+
+  await page.goto("/login");
+  await loginViaUi(page, account);
+
+  await expect(page).toHaveURL(/\/$/);
+  await expectProtectedShell(page, account);
+});
+
+test("shows invalid-credential errors without leaving the login form", async ({
+  page,
+}) => {
+  await page.goto("/login");
+
+  await page.getByLabel(/email/i).fill("missing@example.com");
+  await page.getByLabel(/password/i).fill("wrong-password");
+  await page.getByRole("button", { name: /^sign in$/i }).click();
+
+  await expect(page.getByText("Invalid email or password")).toBeVisible();
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+});
+
+test("honors same-origin callbackUrl after login", async ({
+  page,
+  request,
+}) => {
+  const account = await registerAccount(
+    request,
+    "callback-internal",
+    test.info().parallelIndex,
+  );
+
+  await page.goto("/login?callbackUrl=%2Fsettings");
+  await loginViaUi(page, account);
+
+  await expect(page).toHaveURL(/\/settings$/);
+  await expect(
+    page.getByRole("heading", { name: /^settings$/i }),
+  ).toBeVisible();
+});
+
+for (const callbackUrl of [
+  "https://evil.example/path",
+  "//evil.example/path",
+  "/\\evil.example",
+]) {
+  test(`blocks open redirect callbackUrl ${callbackUrl}`, async ({
+    page,
+    request,
+  }) => {
+    const account = await registerAccount(
+      request,
+      "callback-external",
+      test.info().parallelIndex,
+    );
+
+    await page.goto(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+    await loginViaUi(page, account);
+
+    await expect(page).toHaveURL(/\/$/);
+    await expectProtectedShell(page, account);
+  });
+}
+
+test("redirects no-cookie access to login with callbackUrl", async ({
+  page,
+}) => {
+  await page.goto("/settings");
+
+  await expect(page).toHaveURL(/\/login\?callbackUrl=%2Fsettings$/);
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+});
+
+test("logs out and blocks protected routes afterwards", async ({
+  page,
+  request,
+}) => {
+  const account = await registerAccount(
+    request,
+    "logout",
+    test.info().parallelIndex,
+  );
+
+  await page.goto("/login");
+  await loginViaUi(page, account);
+  await expectProtectedShell(page, account);
+
+  await page.getByRole("button", { name: new RegExp(account.email) }).click();
+  await page.getByRole("menuitem", { name: /log out/i }).click();
+
+  await expectLoginPage(page);
+
+  await page.goto("/settings");
+  await expectLoginPage(page);
+});
+
+test("redirects when a still-present browser cookie has been revoked", async ({
+  page,
+  request,
+}) => {
+  const account = await registerAccount(
+    request,
+    "revoked-session",
+    test.info().parallelIndex,
+  );
+
+  await page.goto("/login");
+  await loginViaUi(page, account);
+  await expectProtectedShell(page, account);
+
+  await revokeAllSessions(request, account);
+  await page.goto("/settings");
+
+  await expectLoginPage(page);
+});

--- a/e2e/auth/auth.spec.ts
+++ b/e2e/auth/auth.spec.ts
@@ -28,13 +28,35 @@ test("shows invalid-credential errors without leaving the login form", async ({
 }) => {
   await page.goto("/login");
 
+  const reloadGuard = `invalid-login-${test.info().parallelIndex}`;
+  await page.evaluate((value) => {
+    (
+      window as Window & { __invalidLoginReloadGuard?: string }
+    ).__invalidLoginReloadGuard = value;
+  }, reloadGuard);
+
   await page.getByLabel(/email/i).fill("missing@example.com");
   await page.getByLabel(/password/i).fill("wrong-password");
+  const loginResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/auth/v1/login") &&
+      response.request().method() === "POST",
+  );
   await page.getByRole("button", { name: /^sign in$/i }).click();
 
+  expect((await loginResponse).status()).toBe(401);
   await expect(page.getByText("Invalid email or password")).toBeVisible();
   await expect(page).toHaveURL(/\/login$/);
   await expect(page.getByLabel(/email/i)).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __invalidLoginReloadGuard?: string })
+            .__invalidLoginReloadGuard ?? null,
+      ),
+    )
+    .toBe(reloadGuard);
 });
 
 test("honors same-origin callbackUrl after login", async ({
@@ -102,7 +124,7 @@ test("logs out and blocks protected routes afterwards", async ({
   await loginViaUi(page, account);
   await expectProtectedShell(page, account);
 
-  await page.getByRole("button", { name: new RegExp(account.email) }).click();
+  await page.getByRole("button", { name: account.email }).click();
   await page.getByRole("menuitem", { name: /log out/i }).click();
 
   await expectLoginPage(page);

--- a/e2e/auth/auth.spec.ts
+++ b/e2e/auth/auth.spec.ts
@@ -1,154 +1,138 @@
-import { expect, test } from "@playwright/test";
 import {
   expectLoginPage,
   expectProtectedShell,
   loginViaUi,
-  registerAccount,
   revokeAllSessions,
-} from "./helpers";
+  test,
+  expect,
+} from "../fixtures";
 
-test.use({ storageState: { cookies: [], origins: [] } });
+const emptyStorageState = { cookies: [], origins: [] };
 
-test("logs in an existing user", async ({ page, request }) => {
-  const account = await registerAccount(
-    request,
-    "login-success",
-    test.info().parallelIndex,
-  );
+test("restores worker-scoped authenticated storage state", async ({
+  page,
+  account,
+}) => {
+  await page.goto("/");
 
-  await page.goto("/login");
-  await loginViaUi(page, account);
-
-  await expect(page).toHaveURL(/\/$/);
   await expectProtectedShell(page, account);
 });
 
-test("shows invalid-credential errors without leaving the login form", async ({
-  page,
-}) => {
-  await page.goto("/login");
+test.describe("anonymous auth flows", () => {
+  test.use({ storageState: emptyStorageState });
 
-  const reloadGuard = `invalid-login-${test.info().parallelIndex}`;
-  await page.evaluate((value) => {
-    (
-      window as Window & { __invalidLoginReloadGuard?: string }
-    ).__invalidLoginReloadGuard = value;
-  }, reloadGuard);
-
-  await page.getByLabel(/email/i).fill("missing@example.com");
-  await page.getByLabel(/password/i).fill("wrong-password");
-  const loginResponse = page.waitForResponse(
-    (response) =>
-      response.url().endsWith("/auth/v1/login") &&
-      response.request().method() === "POST",
-  );
-  await page.getByRole("button", { name: /^sign in$/i }).click();
-
-  expect((await loginResponse).status()).toBe(401);
-  await expect(page.getByText("Invalid email or password")).toBeVisible();
-  await expect(page).toHaveURL(/\/login$/);
-  await expect(page.getByLabel(/email/i)).toBeVisible();
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (window as Window & { __invalidLoginReloadGuard?: string })
-            .__invalidLoginReloadGuard ?? null,
-      ),
-    )
-    .toBe(reloadGuard);
-});
-
-test("honors same-origin callbackUrl after login", async ({
-  page,
-  request,
-}) => {
-  const account = await registerAccount(
-    request,
-    "callback-internal",
-    test.info().parallelIndex,
-  );
-
-  await page.goto("/login?callbackUrl=%2Fsettings");
-  await loginViaUi(page, account);
-
-  await expect(page).toHaveURL(/\/settings$/);
-  await expect(
-    page.getByRole("heading", { name: /^settings$/i }),
-  ).toBeVisible();
-});
-
-for (const callbackUrl of [
-  "https://evil.example/path",
-  "//evil.example/path",
-  "/\\evil.example",
-]) {
-  test(`blocks open redirect callbackUrl ${callbackUrl}`, async ({
-    page,
-    request,
-  }) => {
-    const account = await registerAccount(
-      request,
-      "callback-external",
-      test.info().parallelIndex,
-    );
-
-    await page.goto(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+  test("logs in an existing user", async ({ page, account }) => {
+    await page.goto("/login");
     await loginViaUi(page, account);
 
     await expect(page).toHaveURL(/\/$/);
     await expectProtectedShell(page, account);
   });
-}
 
-test("redirects no-cookie access to login with callbackUrl", async ({
-  page,
-}) => {
-  await page.goto("/settings");
+  test("shows invalid-credential errors without leaving the login form", async ({
+    page,
+  }) => {
+    await page.goto("/login");
 
-  await expect(page).toHaveURL(/\/login\?callbackUrl=%2Fsettings$/);
-  await expect(page.getByLabel(/email/i)).toBeVisible();
-});
+    const reloadGuard = `invalid-login-${test.info().parallelIndex}`;
+    await page.evaluate((value) => {
+      (
+        window as Window & { __invalidLoginReloadGuard?: string }
+      ).__invalidLoginReloadGuard = value;
+    }, reloadGuard);
 
-test("logs out and blocks protected routes afterwards", async ({
-  page,
-  request,
-}) => {
-  const account = await registerAccount(
+    await page.getByLabel(/email/i).fill("missing@example.com");
+    await page.getByLabel(/password/i).fill("wrong-password");
+    const loginResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/auth/v1/login") &&
+        response.request().method() === "POST",
+    );
+    await page.getByRole("button", { name: /^sign in$/i }).click();
+
+    expect((await loginResponse).status()).toBe(401);
+    await expect(page.getByText("Invalid email or password")).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as Window & { __invalidLoginReloadGuard?: string })
+              .__invalidLoginReloadGuard ?? null,
+        ),
+      )
+      .toBe(reloadGuard);
+  });
+
+  test("honors same-origin callbackUrl after login", async ({
+    page,
+    account,
+  }) => {
+    await page.goto("/login?callbackUrl=%2Fsettings");
+    await loginViaUi(page, account);
+
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(
+      page.getByRole("heading", { name: /^settings$/i }),
+    ).toBeVisible();
+  });
+
+  for (const callbackUrl of [
+    "https://evil.example/path",
+    "//evil.example/path",
+    "/\\evil.example",
+  ]) {
+    test(`blocks open redirect callbackUrl ${callbackUrl}`, async ({
+      page,
+      account,
+    }) => {
+      await page.goto(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+      await loginViaUi(page, account);
+
+      await expect(page).toHaveURL(/\/$/);
+      await expectProtectedShell(page, account);
+    });
+  }
+
+  test("redirects no-cookie access to login with callbackUrl", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+
+    await expect(page).toHaveURL(/\/login\?callbackUrl=%2Fsettings$/);
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+  });
+
+  test("logs out and blocks protected routes afterwards", async ({
+    page,
+    freshAccount,
+  }) => {
+    await page.goto("/login");
+    await loginViaUi(page, freshAccount);
+    await expectProtectedShell(page, freshAccount);
+
+    await page.getByRole("button", { name: freshAccount.email }).click();
+    await page.getByRole("menuitem", { name: /log out/i }).click();
+
+    await expectLoginPage(page);
+
+    await page.goto("/settings");
+    await expectLoginPage(page);
+  });
+
+  test("redirects when a still-present browser cookie has been revoked", async ({
+    page,
     request,
-    "logout",
-    test.info().parallelIndex,
-  );
+    freshAccount,
+  }) => {
+    await page.goto("/login");
+    await loginViaUi(page, freshAccount);
+    await expectProtectedShell(page, freshAccount);
 
-  await page.goto("/login");
-  await loginViaUi(page, account);
-  await expectProtectedShell(page, account);
+    await revokeAllSessions(request, freshAccount);
+    await page.goto("/settings");
 
-  await page.getByRole("button", { name: account.email }).click();
-  await page.getByRole("menuitem", { name: /log out/i }).click();
-
-  await expectLoginPage(page);
-
-  await page.goto("/settings");
-  await expectLoginPage(page);
-});
-
-test("redirects when a still-present browser cookie has been revoked", async ({
-  page,
-  request,
-}) => {
-  const account = await registerAccount(
-    request,
-    "revoked-session",
-    test.info().parallelIndex,
-  );
-
-  await page.goto("/login");
-  await loginViaUi(page, account);
-  await expectProtectedShell(page, account);
-
-  await revokeAllSessions(request, account);
-  await page.goto("/settings");
-
-  await expectLoginPage(page);
+    await expectLoginPage(page);
+  });
 });

--- a/e2e/auth/helpers.ts
+++ b/e2e/auth/helpers.ts
@@ -1,0 +1,91 @@
+import { expect, type APIRequestContext, type Page } from "@playwright/test";
+
+const apiUrl =
+  process.env.NEXT_PUBLIC_API_URL ??
+  `http://localhost:${process.env.E2E_API_PORT ?? "4301"}`;
+const password = "Password123!";
+
+export type TestAccount = {
+  email: string;
+  name: string;
+  password: string;
+  token: string;
+};
+
+export function uniqueEmail(label: string, parallelIndex: number): string {
+  return `e2e-${label}-${Date.now()}-${parallelIndex}-${Math.random().toString(36).slice(2)}@example.com`;
+}
+
+export async function registerAccount(
+  request: APIRequestContext,
+  label: string,
+  parallelIndex: number,
+): Promise<TestAccount> {
+  const email = uniqueEmail(label, parallelIndex);
+  const name = `E2E ${label}`;
+  const response = await request.post(`${apiUrl}/auth/v1/register`, {
+    data: { email, name, password },
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to register ${email}: ${response.status()} ${await response.text()}`,
+    );
+  }
+
+  const body = (await response.json()) as { token?: string };
+  if (!body.token) {
+    throw new Error(`Register response for ${email} did not include a token`);
+  }
+
+  return { email, name, password, token: body.token };
+}
+
+export async function loginViaUi(
+  page: Page,
+  account: TestAccount,
+): Promise<void> {
+  await page.getByLabel(/email/i).fill(account.email);
+  await page.getByLabel(/password/i).fill(account.password);
+  const loginResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/auth/v1/login") &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: /^sign in$/i }).click();
+
+  const response = await loginResponse;
+  expect(response.status()).toBe(200);
+}
+
+export async function expectProtectedShell(page: Page, account: TestAccount) {
+  await expect(page.getByText(account.email)).toBeVisible({ timeout: 15_000 });
+  await expect(
+    page.getByPlaceholder(/what would you like to know/i),
+  ).toBeVisible();
+}
+
+export async function revokeAllSessions(
+  request: APIRequestContext,
+  account: TestAccount,
+): Promise<void> {
+  const response = await request.delete(`${apiUrl}/auth/v1/sessions`, {
+    headers: {
+      Authorization: `Bearer ${account.token}`,
+    },
+    params: {
+      scope: "all",
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to revoke sessions for ${account.email}: ${response.status()} ${await response.text()}`,
+    );
+  }
+}
+
+export async function expectLoginPage(page: Page) {
+  await expect(page).toHaveURL(/\/login(?:\?|$)/);
+  await expect(page.getByLabel(/email/i)).toBeVisible();
+}

--- a/e2e/db-server.ts
+++ b/e2e/db-server.ts
@@ -1,0 +1,192 @@
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { dirname, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const container = process.env.E2E_DB_CONTAINER ?? "llame-e2e-postgres";
+const image = process.env.E2E_DB_PG_IMAGE ?? "postgres:17-alpine";
+const dbPort = process.env.E2E_DB_PORT ?? "55433";
+const readyPort = Number(process.env.E2E_DB_READY_PORT ?? "4302");
+const postgresUrl =
+  process.env.POSTGRES_URL ??
+  `postgres://app:app@localhost:${dbPort}/llame_e2e`;
+const databaseName = new URL(postgresUrl).pathname.replace(/^\//, "");
+
+let server: Server | undefined;
+let shuttingDown = false;
+let resolveShutdown: (() => void) | undefined;
+const shutdown = new Promise<void>((resolve) => {
+  resolveShutdown = resolve;
+});
+
+function requestShutdown(): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  resolveShutdown?.();
+}
+
+process.once("SIGINT", requestShutdown);
+process.once("SIGTERM", requestShutdown);
+
+function run(
+  command: string,
+  args: string[],
+  options: SpawnSyncOptions = {},
+): void {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed`);
+  }
+}
+
+function runWithInput(command: string, args: string[], input: string): void {
+  run(command, args, {
+    input,
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+}
+
+async function cleanup(): Promise<void> {
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+    server = undefined;
+  }
+
+  spawnSync("docker", ["rm", "-f", container], { stdio: "ignore" });
+}
+
+async function waitForPostgres(): Promise<void> {
+  process.stdout.write("waiting for postgres");
+
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const result = spawnSync(
+      "docker",
+      ["exec", container, "pg_isready", "-U", "postgres"],
+      { stdio: "ignore" },
+    );
+
+    if (result.status === 0) {
+      process.stdout.write(" ready\n");
+      return;
+    }
+
+    process.stdout.write(".");
+    await sleep(1_000);
+  }
+
+  process.stdout.write(" timeout\n");
+  throw new Error("Postgres did not become ready within 60s");
+}
+
+function provisionDatabase(): void {
+  runWithInput(
+    "docker",
+    [
+      "exec",
+      "-i",
+      container,
+      "psql",
+      "-U",
+      "postgres",
+      "-v",
+      "ON_ERROR_STOP=1",
+    ],
+    `
+CREATE ROLE app LOGIN PASSWORD 'app' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
+CREATE DATABASE ${databaseName} OWNER app;
+`,
+  );
+
+  runWithInput(
+    "docker",
+    [
+      "exec",
+      "-i",
+      container,
+      "psql",
+      "-U",
+      "postgres",
+      "-d",
+      databaseName,
+      "-v",
+      "ON_ERROR_STOP=1",
+    ],
+    "ALTER SCHEMA public OWNER TO app;\n",
+  );
+}
+
+function migrateDatabase(): void {
+  run("pnpm", ["--filter", "api", "db:migrate"], {
+    env: { ...process.env, POSTGRES_URL: postgresUrl },
+  });
+}
+
+async function startReadyServer(): Promise<void> {
+  server = createServer((request, response) => {
+    if (request.url === "/ready") {
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("ok");
+      return;
+    }
+
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end("not found");
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject);
+    server?.listen(readyPort, "127.0.0.1", resolve);
+  });
+
+  console.log(`e2e database ready on ${postgresUrl}`);
+}
+
+async function waitForShutdown(): Promise<void> {
+  await shutdown;
+}
+
+async function main(): Promise<void> {
+  try {
+    await cleanup();
+    run("docker", [
+      "run",
+      "-d",
+      "--name",
+      container,
+      "-e",
+      "POSTGRES_PASSWORD=postgres",
+      "-p",
+      `${dbPort}:5432`,
+      image,
+    ]);
+    if (shuttingDown) return;
+    await waitForPostgres();
+    if (shuttingDown) return;
+    provisionDatabase();
+    if (shuttingDown) return;
+    migrateDatabase();
+    if (shuttingDown) return;
+    await startReadyServer();
+    await waitForShutdown();
+  } finally {
+    await cleanup();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/e2e/db-server.ts
+++ b/e2e/db-server.ts
@@ -55,17 +55,21 @@ function runWithInput(command: string, args: string[], input: string): void {
 }
 
 async function cleanup(): Promise<void> {
-  if (server) {
+  try {
+    const readyServer = server;
+    server = undefined;
+
+    if (!readyServer) return;
+
     await new Promise<void>((resolve, reject) => {
-      server?.close((error) => {
+      readyServer.close((error) => {
         if (error) reject(error);
         else resolve();
       });
     });
-    server = undefined;
+  } finally {
+    spawnSync("docker", ["rm", "-f", container], { stdio: "ignore" });
   }
-
-  spawnSync("docker", ["rm", "-f", container], { stdio: "ignore" });
 }
 
 async function waitForPostgres(): Promise<void> {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  request as playwrightRequest,
+  test as baseTest,
+} from "@playwright/test";
+import playwrightConfig from "../playwright.config";
+import {
+  expectProtectedShell,
+  loginViaUi,
+  registerAccount,
+  type TestAccount,
+} from "./auth/helpers";
+
+export * from "@playwright/test";
+export * from "./auth/helpers";
+
+type Fixtures = {
+  account: TestAccount;
+  freshAccount: TestAccount;
+};
+
+type WorkerFixtures = {
+  workerAccount: TestAccount;
+  workerStorageState: string;
+};
+
+export const test = baseTest.extend<Fixtures, WorkerFixtures>({
+  account: async ({ workerAccount }, use) => {
+    await use(workerAccount);
+  },
+
+  freshAccount: async ({}, use) => {
+    const request = await playwrightRequest.newContext();
+
+    try {
+      await use(
+        await registerAccount(
+          request,
+          `fresh-${test.info().retry}`,
+          test.info().parallelIndex,
+        ),
+      );
+    } finally {
+      await request.dispose();
+    }
+  },
+
+  storageState: ({ workerStorageState }, use) => use(workerStorageState),
+
+  workerAccount: [
+    async ({}, use) => {
+      const request = await playwrightRequest.newContext();
+
+      try {
+        await use(
+          await registerAccount(
+            request,
+            `worker-${test.info().parallelIndex}`,
+            test.info().parallelIndex,
+          ),
+        );
+      } finally {
+        await request.dispose();
+      }
+    },
+    { scope: "worker" },
+  ],
+
+  workerStorageState: [
+    async ({ browser, workerAccount }, use) => {
+      const fileName = path.resolve(
+        test.info().project.outputDir,
+        `.auth/${test.info().parallelIndex}.json`,
+      );
+
+      if (!fs.existsSync(fileName)) {
+        fs.mkdirSync(path.dirname(fileName), { recursive: true });
+
+        const page = await browser.newPage({
+          baseURL:
+            typeof playwrightConfig.use?.baseURL === "string"
+              ? playwrightConfig.use.baseURL
+              : undefined,
+          storageState: undefined,
+        });
+
+        try {
+          await page.goto("/login");
+          await loginViaUi(page, workerAccount);
+          await expectProtectedShell(page, workerAccount);
+          await page.context().storageState({ path: fileName });
+        } finally {
+          await page.close();
+        }
+      }
+
+      await use(fileName);
+    },
+    { scope: "worker" },
+  ],
+});

--- a/e2e/run-after-ready.ts
+++ b/e2e/run-after-ready.ts
@@ -1,0 +1,59 @@
+import { spawn } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const [url, command, ...args] = process.argv.slice(2);
+
+if (!url || !command) {
+  console.error("Usage: run-after-ready <url> <command> [...args]");
+  process.exit(1);
+}
+
+async function waitForUrl(): Promise<void> {
+  const timeout = Date.now() + 120_000;
+
+  while (Date.now() < timeout) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {}
+
+    await sleep(500);
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function main(): Promise<void> {
+  await waitForUrl();
+
+  const executable =
+    process.platform === "win32" && command === "pnpm" ? "pnpm.cmd" : command;
+  const child = spawn(executable, args, {
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  function forward(signal: NodeJS.Signals): void {
+    child.kill(signal);
+  }
+
+  process.once("SIGINT", forward);
+  process.once("SIGTERM", forward);
+
+  await new Promise<void>((resolve) => {
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+
+      process.exitCode = code ?? 0;
+      resolve();
+    });
+  });
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "dev": "turbo dev",
     "lint": "turbo lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
+    "test:e2e:report": "playwright show-report",
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
     "db:reset": "docker compose down -v && docker compose up -d",
@@ -17,6 +22,7 @@
     "db:psql": "docker compose exec -e PGPASSWORD=app postgres psql -U app -d llame"
   },
   "devDependencies": {
+    "@playwright/test": "1.53.2",
     "@workspace/config-eslint": "workspace:*",
     "@workspace/config-typescript": "workspace:*",
     "prettier": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -26,15 +26,13 @@
     "@workspace/config-eslint": "workspace:*",
     "@workspace/config-typescript": "workspace:*",
     "prettier": "^3.5.1",
+    "tsx": "^4.20.3",
     "turbo": "^2.4.2",
     "typescript": "5.7.3"
   },
   "packageManager": "pnpm@10.4.1",
   "engines": {
     "node": ">=20"
-  },
-  "dependencies": {
-    "tsx": "^4.20.3"
   },
   "pnpm": {
     "ignoredBuiltDependencies": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,36 +11,16 @@ const startDatabase = !process.env.POSTGRES_URL;
 const postgresUrl =
   process.env.POSTGRES_URL ??
   `postgres://app:app@localhost:${dbPort}/llame_e2e`;
+const processEnv: Record<string, string> = Object.fromEntries(
+  Object.entries(process.env).filter(
+    (entry): entry is [string, string] => entry[1] !== undefined,
+  ),
+);
 
-function env(name: string, value: string): string {
-  return `${name}=${JSON.stringify(value)}`;
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-function waitForUrl(url: string): string {
-  const script = `
-const url = ${JSON.stringify(url)};
-const timeout = Date.now() + 120_000;
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-while (Date.now() < timeout) {
-  try {
-    const response = await fetch(url);
-    if (response.ok) process.exit(0);
-  } catch {
-  }
-
-  await sleep(500);
-}
-
-console.error("Timed out waiting for " + url);
-process.exit(1);
-`;
-
-  return `node -e ${shellQuote(script)}`;
+function webServerEnv(
+  overrides: Record<string, string>,
+): Record<string, string> {
+  return { ...processEnv, ...overrides };
 }
 
 export default defineConfig({
@@ -72,20 +52,16 @@ export default defineConfig({
       ? [
           {
             name: "db",
-            command: [
-              env("E2E_DB_PORT", dbPort),
-              env("E2E_DB_READY_PORT", dbReadyPort),
-              env(
-                "E2E_DB_CONTAINER",
+            command: "node --import tsx e2e/db-server.ts",
+            env: webServerEnv({
+              E2E_DB_PORT: dbPort,
+              E2E_DB_READY_PORT: dbReadyPort,
+              E2E_DB_CONTAINER:
                 process.env.E2E_DB_CONTAINER ?? "llame-e2e-postgres",
-              ),
-              env(
-                "E2E_DB_PG_IMAGE",
+              E2E_DB_PG_IMAGE:
                 process.env.E2E_DB_PG_IMAGE ?? "postgres:17-alpine",
-              ),
-              env("POSTGRES_URL", postgresUrl),
-              "exec node --import tsx e2e/db-server.ts",
-            ].join(" "),
+              POSTGRES_URL: postgresUrl,
+            }),
             url: dbReadyUrl,
             timeout: 180_000,
             reuseExistingServer: false,
@@ -97,15 +73,16 @@ export default defineConfig({
       : []),
     {
       name: "api",
-      command: [
-        ...(startDatabase ? [`${waitForUrl(dbReadyUrl)} &&`] : []),
-        env("NODE_ENV", "development"),
-        env("PORT", apiPort),
-        env("POSTGRES_URL", postgresUrl),
-        env("WEB_ORIGIN", webUrl),
-        env("SESSION_COOKIE_DOMAIN", ""),
-        "pnpm --filter api dev",
-      ].join(" "),
+      command: startDatabase
+        ? `node --import tsx e2e/run-after-ready.ts ${dbReadyUrl} pnpm --filter api dev`
+        : "pnpm --filter api dev",
+      env: webServerEnv({
+        NODE_ENV: "development",
+        PORT: apiPort,
+        POSTGRES_URL: postgresUrl,
+        WEB_ORIGIN: webUrl,
+        SESSION_COOKIE_DOMAIN: "",
+      }),
       url: apiUrl,
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,
@@ -114,11 +91,11 @@ export default defineConfig({
     },
     {
       name: "web",
-      command: [
-        env("NODE_ENV", "development"),
-        env("NEXT_PUBLIC_API_URL", apiUrl),
-        `pnpm --filter web exec next dev --turbopack --hostname localhost --port ${webPort}`,
-      ].join(" "),
+      command: `pnpm --filter web exec next dev --turbopack --hostname localhost --port ${webPort}`,
+      env: webServerEnv({
+        NODE_ENV: "development",
+        NEXT_PUBLIC_API_URL: apiUrl,
+      }),
       url: `${webUrl}/login`,
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const webPort = process.env.E2E_WEB_PORT ?? "4300";
+const apiPort = process.env.E2E_API_PORT ?? "4301";
+const webUrl = `http://localhost:${webPort}`;
+const apiUrl = `http://localhost:${apiPort}`;
+const postgresUrl =
+  process.env.POSTGRES_URL ?? "postgres://app:app@localhost:5432/llame";
+
+function env(name: string, value: string): string {
+  return `${name}=${JSON.stringify(value)}`;
+}
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"], ["list"]]
+    : [["html", { open: "never" }], ["list"]],
+  expect: {
+    timeout: 15_000,
+  },
+  use: {
+    baseURL: webUrl,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      name: "api",
+      command: [
+        env("NODE_ENV", "development"),
+        env("PORT", apiPort),
+        env("POSTGRES_URL", postgresUrl),
+        env("WEB_ORIGIN", webUrl),
+        env("SESSION_COOKIE_DOMAIN", ""),
+        "pnpm --filter api dev",
+      ].join(" "),
+      url: apiUrl,
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      name: "web",
+      command: [
+        env("NODE_ENV", "development"),
+        env("NEXT_PUBLIC_API_URL", apiUrl),
+        `pnpm --filter web exec next dev --turbopack --hostname localhost --port ${webPort}`,
+      ].join(" "),
+      url: `${webUrl}/login`,
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,20 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const webPort = process.env.E2E_WEB_PORT ?? "4300";
-const apiPort = process.env.E2E_API_PORT ?? "4301";
-const dbPort = process.env.E2E_DB_PORT ?? "55433";
-const dbReadyPort = process.env.E2E_DB_READY_PORT ?? "4302";
+function readPort(name: string, fallback: string): string {
+  const value = process.env[name] ?? fallback;
+  const port = Number(value);
+
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`${name} must be a TCP port number`);
+  }
+
+  return String(port);
+}
+
+const webPort = readPort("E2E_WEB_PORT", "4300");
+const apiPort = readPort("E2E_API_PORT", "4301");
+const dbPort = readPort("E2E_DB_PORT", "55433");
+const dbReadyPort = readPort("E2E_DB_READY_PORT", "4302");
 const webUrl = `http://localhost:${webPort}`;
 const apiUrl = `http://localhost:${apiPort}`;
 const dbReadyUrl = `http://localhost:${dbReadyPort}/ready`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,13 +2,45 @@ import { defineConfig, devices } from "@playwright/test";
 
 const webPort = process.env.E2E_WEB_PORT ?? "4300";
 const apiPort = process.env.E2E_API_PORT ?? "4301";
+const dbPort = process.env.E2E_DB_PORT ?? "55433";
+const dbReadyPort = process.env.E2E_DB_READY_PORT ?? "4302";
 const webUrl = `http://localhost:${webPort}`;
 const apiUrl = `http://localhost:${apiPort}`;
+const dbReadyUrl = `http://localhost:${dbReadyPort}/ready`;
+const startDatabase = !process.env.POSTGRES_URL;
 const postgresUrl =
-  process.env.POSTGRES_URL ?? "postgres://app:app@localhost:5432/llame";
+  process.env.POSTGRES_URL ??
+  `postgres://app:app@localhost:${dbPort}/llame_e2e`;
 
 function env(name: string, value: string): string {
   return `${name}=${JSON.stringify(value)}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function waitForUrl(url: string): string {
+  const script = `
+const url = ${JSON.stringify(url)};
+const timeout = Date.now() + 120_000;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+while (Date.now() < timeout) {
+  try {
+    const response = await fetch(url);
+    if (response.ok) process.exit(0);
+  } catch {
+  }
+
+  await sleep(500);
+}
+
+console.error("Timed out waiting for " + url);
+process.exit(1);
+`;
+
+  return `node -e ${shellQuote(script)}`;
 }
 
 export default defineConfig({
@@ -36,9 +68,37 @@ export default defineConfig({
     },
   ],
   webServer: [
+    ...(startDatabase
+      ? [
+          {
+            name: "db",
+            command: [
+              env("E2E_DB_PORT", dbPort),
+              env("E2E_DB_READY_PORT", dbReadyPort),
+              env(
+                "E2E_DB_CONTAINER",
+                process.env.E2E_DB_CONTAINER ?? "llame-e2e-postgres",
+              ),
+              env(
+                "E2E_DB_PG_IMAGE",
+                process.env.E2E_DB_PG_IMAGE ?? "postgres:17-alpine",
+              ),
+              env("POSTGRES_URL", postgresUrl),
+              "exec node --import tsx e2e/db-server.ts",
+            ].join(" "),
+            url: dbReadyUrl,
+            timeout: 180_000,
+            reuseExistingServer: false,
+            gracefulShutdown: { signal: "SIGTERM", timeout: 30_000 },
+            stdout: "pipe",
+            stderr: "pipe",
+          },
+        ]
+      : []),
     {
       name: "api",
       command: [
+        ...(startDatabase ? [`${waitForUrl(dbReadyUrl)} &&`] : []),
         env("NODE_ENV", "development"),
         env("PORT", apiPort),
         env("POSTGRES_URL", postgresUrl),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.3
     devDependencies:
       '@playwright/test':
         specifier: 1.53.2
@@ -24,6 +20,9 @@ importers:
       prettier:
         specifier: ^3.5.1
         version: 3.5.1
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       turbo:
         specifier: ^2.4.2
         version: 2.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^4.20.3
         version: 4.20.3
     devDependencies:
+      '@playwright/test':
+        specifier: 1.53.2
+        version: 1.53.2
       '@workspace/config-eslint':
         specifier: workspace:*
         version: link:packages/config-eslint
@@ -8926,7 +8929,6 @@ snapshots:
   '@playwright/test@1.53.2':
     dependencies:
       playwright: 1.53.2
-    optional: true
 
   '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -13774,15 +13776,13 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.53.2:
-    optional: true
+  playwright-core@1.53.2: {}
 
   playwright@1.53.2:
     dependencies:
       playwright-core: 1.53.2
     optionalDependencies:
       fsevents: 2.3.2
-    optional: true
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
Closes #79

## Summary
- Adds a root Playwright config that starts `apps/api` and `apps/web` on E2E ports against a migrated Postgres database.
- Adds browser auth coverage for login success/failure, same-origin callback redirects, blocked open redirects, no-cookie redirects, logout, and revoked-session redirects.
- Adds the generic Playwright script set used in whoard: `test:e2e`, `test:e2e:ui`, `test:e2e:headed`, `test:e2e:debug`, and `test:e2e:report`, with AGENTS.md usage notes.

## Verification
- `pnpm test:e2e -- e2e/auth`
- `pnpm --filter web test`
- `pnpm --filter api test`
- `pnpm --filter api test:e2e`
- `pnpm build`
- `pnpm exec prettier --check CHANGELOG.md package.json playwright.config.ts e2e/auth/auth.spec.ts e2e/auth/helpers.ts`
- `pnpm lint` currently fails before project code linting because `@workspace/ui` invokes `eslint` without a direct binary; forcing an eslint binary shows existing `@workspace/ui` warnings under `--max-warnings 0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright E2E auth tests with an isolated Postgres that migrates on boot. The harness starts `apps/api` and `apps/web`, waits for DB readiness, reuses worker-scoped authenticated browser state, and verifies login, safe redirects, logout, and revoked sessions for the auth cutover.

- **New Features**
  - Root `playwright` config can start a throwaway Docker Postgres via `e2e/db-server.ts` (skipped if `POSTGRES_URL` is set), exposes `/ready`, then boots both apps; env/ports: `E2E_WEB_PORT`, `E2E_API_PORT`, `E2E_DB_PORT`, `E2E_DB_READY_PORT`, `NEXT_PUBLIC_API_URL`, `E2E_DB_CONTAINER`, `E2E_DB_PG_IMAGE`.
  - API startup waits for DB readiness via `e2e/run-after-ready.ts`.
  - Worker-scoped fixtures create and cache an authenticated storage state under `.auth/`, and expose `account` and `freshAccount` helpers for tests.
  - Browser coverage: login success/failure, same-origin callback redirects, blocked open redirects, no-cookie redirect to login, logout, and revoked-session redirects. Added scripts: `test:e2e`, `test:e2e:ui`, `test:e2e:headed`, `test:e2e:debug`, `test:e2e:report`.

- **Bug Fixes**
  - Hardened DB teardown: graceful shutdown of the ready server and Docker container on SIGINT/SIGTERM to avoid leaks.

<sup>Written for commit a816474ecaa56bb2934b20e61af1266e05bd416e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser-based end-to-end authentication coverage, including login/logout, protected-page access, callback redirect safety, and session revocation behavior.
  * Added Playwright end-to-end tooling and commands for running, headed/debug runs, and viewing reports.
* **Tests**
  * Expanded automated checks to verify invalid login handling, redirect preservation to safe destinations, and server-side session revocation redirects.
* **Documentation**
  * Updated E2E setup and command guidance (including running scoped to a workspace and handling local DB/browser setup).
  * Added a changelog entry for the auth cutover E2E coverage.
* **Chores**
  * Added ignore rules for generated E2E artifacts and reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->