### PR TITLE
feat(api): expose chat message history

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -470,6 +470,7 @@
             "description": "Return messages strictly before this sequence number.",
             "schema": {
               "minimum": 1,
+              "maximum": 9007199254740991,
               "format": "int64",
               "type": "integer"
             }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -449,6 +449,30 @@
               "format": "uuid",
               "type": "string"
             }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Maximum number of latest messages to return.",
+            "schema": {
+              "minimum": 1,
+              "maximum": 200,
+              "format": "int32",
+              "default": 100,
+              "type": "integer"
+            }
+          },
+          {
+            "name": "beforeSeq",
+            "required": false,
+            "in": "query",
+            "description": "Return messages strictly before this sequence number.",
+            "schema": {
+              "minimum": 1,
+              "format": "int64",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -463,7 +487,7 @@
             }
           },
           "400": {
-            "description": "Malformed chat id (not a UUID)"
+            "description": "Malformed chat id or invalid history pagination query"
           },
           "401": {
             "description": ""

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -438,6 +438,52 @@
       }
     },
     "/api/v1/chats/{id}/messages": {
+      "get": {
+        "operationId": "ChatsController_getChatMessages",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatMessagesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed chat id (not a UUID)"
+          },
+          "401": {
+            "description": ""
+          },
+          "404": {
+            "description": "Chat not found or not owned"
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": [
+          "chats"
+        ]
+      },
       "post": {
         "operationId": "ChatsController_createMessage",
         "parameters": [
@@ -717,6 +763,90 @@
           "visibility",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "ChatMessageResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "chatId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "seq": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "assistant",
+              "system",
+              "tool"
+            ]
+          },
+          "senderUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "parts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "usage": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true
+          },
+          "inReplyTo": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "chatId",
+          "seq",
+          "role",
+          "senderUserId",
+          "parts",
+          "attachments",
+          "usage",
+          "inReplyTo",
+          "createdAt"
+        ]
+      },
+      "ChatMessagesResponse": {
+        "type": "object",
+        "properties": {
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessageResponse"
+            }
+          }
+        },
+        "required": [
+          "messages"
         ]
       },
       "CreateTextMessagePartDto": {

--- a/apps/api/scripts/rls-test.sh
+++ b/apps/api/scripts/rls-test.sh
@@ -29,7 +29,7 @@ docker run -d --name "$CONTAINER" -e POSTGRES_PASSWORD=postgres \
 echo -n "▶ waiting for postgres"
 ready=false
 for _ in $(seq 1 60); do
-  if docker exec "$CONTAINER" pg_isready -U postgres >/dev/null 2>&1; then ready=true; break; fi
+  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then ready=true; break; fi
   echo -n "."; sleep 1
 done
 if [ "$ready" != true ]; then
@@ -40,12 +40,14 @@ fi
 echo " ready"
 
 echo "▶ provisioning non-superuser owner role 'app'"
-docker exec -i "$CONTAINER" psql -U postgres -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+docker exec -e PGPASSWORD=postgres -i "$CONTAINER" \
+  psql -h 127.0.0.1 -U postgres -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
 CREATE ROLE app LOGIN PASSWORD 'app' NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
 CREATE DATABASE llame_test OWNER app;
 SQL
 # app must own schema `public` to create tables in it (PG15+ locks this down).
-docker exec -i "$CONTAINER" psql -U postgres -d llame_test -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+docker exec -e PGPASSWORD=postgres -i "$CONTAINER" \
+  psql -h 127.0.0.1 -U postgres -d llame_test -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
 ALTER SCHEMA public OWNER TO app;
 SQL
 

--- a/apps/api/src/chats/chats-rls.integration.spec.ts
+++ b/apps/api/src/chats/chats-rls.integration.spec.ts
@@ -323,5 +323,69 @@ describeIfDb(
       // B must not see A's chat — this proves RLS is engaged at the service layer.
       expect(leaked).toBeUndefined();
     });
+
+    it('getChatMessages returns owned history but hides the same chat from another user', async () => {
+      const chat = await svc.createChat({
+        ownerUserId: userAId,
+        title: 'History Chat',
+      });
+
+      await db.transaction(async (tx) => {
+        await tx.execute(
+          dsql`select set_config('app.current_user_id', ${userAId}, true)`,
+        );
+        const messagesRepo = new MessagesRepository(tx as unknown as Db);
+        const userMessageId = crypto.randomUUID();
+        await messagesRepo.create({
+          id: userMessageId,
+          chatId: chat.id,
+          role: 'user',
+          senderUserId: userAId,
+          parts: [{ type: 'text', text: 'First' }],
+          attachments: [{ type: 'file', name: 'context.txt' }],
+        });
+        await messagesRepo.create({
+          id: crypto.randomUUID(),
+          chatId: chat.id,
+          role: 'assistant',
+          senderUserId: null,
+          parts: [{ type: 'text', text: 'Second' }],
+          attachments: [],
+          usage: { status: 'completed', cachedInputTokens: 1 },
+          inReplyTo: userMessageId,
+        });
+      });
+
+      const aMessages = await svc.getChatMessages(chat.id, userAId);
+      expect(aMessages).toHaveLength(2);
+      expect(aMessages?.[0]).toEqual(
+        expect.objectContaining({
+          chatId: chat.id,
+          seq: expect.any(Number),
+          role: 'user',
+          senderUserId: userAId,
+          parts: [{ type: 'text', text: 'First' }],
+          attachments: [{ type: 'file', name: 'context.txt' }],
+          usage: null,
+          inReplyTo: null,
+        }),
+      );
+      expect(aMessages?.[1]).toEqual(
+        expect.objectContaining({
+          chatId: chat.id,
+          seq: expect.any(Number),
+          role: 'assistant',
+          senderUserId: null,
+          parts: [{ type: 'text', text: 'Second' }],
+          attachments: [],
+          usage: { status: 'completed', cachedInputTokens: 1 },
+          inReplyTo: aMessages?.[0]?.id,
+        }),
+      );
+      expect(aMessages?.[0]?.seq).toBeLessThan(aMessages?.[1]?.seq ?? 0);
+
+      const bMessages = await svc.getChatMessages(chat.id, userBId);
+      expect(bMessages).toBeUndefined();
+    });
   },
 );

--- a/apps/api/src/chats/chats-rls.integration.spec.ts
+++ b/apps/api/src/chats/chats-rls.integration.spec.ts
@@ -356,7 +356,9 @@ describeIfDb(
         });
       });
 
-      const aMessages = await svc.getChatMessages(chat.id, userAId);
+      const aMessages = await svc.getChatMessages(chat.id, userAId, {
+        limit: 100,
+      });
       expect(aMessages).toHaveLength(2);
       expect(aMessages?.[0]).toEqual(
         expect.objectContaining({
@@ -384,7 +386,9 @@ describeIfDb(
       );
       expect(aMessages?.[0]?.seq).toBeLessThan(aMessages?.[1]?.seq ?? 0);
 
-      const bMessages = await svc.getChatMessages(chat.id, userBId);
+      const bMessages = await svc.getChatMessages(chat.id, userBId, {
+        limit: 100,
+      });
       expect(bMessages).toBeUndefined();
     });
   },

--- a/apps/api/src/chats/chats.controller.spec.ts
+++ b/apps/api/src/chats/chats.controller.spec.ts
@@ -92,11 +92,14 @@ describe('ChatsController', () => {
   it('reads chat messages for the verified user only', async () => {
     const { controller, chatsService } = makeController();
 
-    const result = await controller.getChatMessages('verified-user', chat.id);
+    const result = await controller.getChatMessages('verified-user', chat.id, {
+      limit: 100,
+    });
 
     expect(chatsService.getChatMessages).toHaveBeenCalledWith(
       chat.id,
       'verified-user',
+      { limit: 100, beforeSeq: undefined },
     );
     expect(result).toEqual({
       messages: [
@@ -134,7 +137,7 @@ describe('ChatsController', () => {
     });
 
     await expect(
-      controller.getChatMessages('verified-user', chat.id),
+      controller.getChatMessages('verified-user', chat.id, { limit: 100 }),
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
@@ -144,8 +147,23 @@ describe('ChatsController', () => {
     });
 
     await expect(
-      controller.getChatMessages('verified-user', chat.id),
+      controller.getChatMessages('verified-user', chat.id, { limit: 100 }),
     ).resolves.toEqual({ messages: [] });
+  });
+
+  it('passes message history pagination options to the service', async () => {
+    const { controller, chatsService } = makeController();
+
+    await controller.getChatMessages('verified-user', chat.id, {
+      limit: 25,
+      beforeSeq: 42,
+    });
+
+    expect(chatsService.getChatMessages).toHaveBeenCalledWith(
+      chat.id,
+      'verified-user',
+      { limit: 25, beforeSeq: 42 },
+    );
   });
 
   it('patches a chat scoped to the verified user only', async () => {

--- a/apps/api/src/chats/chats.controller.spec.ts
+++ b/apps/api/src/chats/chats.controller.spec.ts
@@ -6,7 +6,7 @@ import type { Request, Response as ExpressResponse } from 'express';
 import { ChatsController } from './chats.controller';
 import type { ChatLoopService } from './chat-loop.service';
 import type { ChatsService } from './chats.service';
-import type { Chat } from '../db/schema';
+import type { Chat, Message } from '../db/schema';
 
 const chat: Chat = {
   id: '0b6f5499-dde4-43cf-89fe-037998a0fe64',
@@ -16,6 +16,33 @@ const chat: Chat = {
   createdAt: new Date('2026-06-29T00:00:00.000Z'),
   updatedAt: new Date('2026-06-29T00:00:00.000Z'),
 };
+
+const chatMessages: Message[] = [
+  {
+    id: '65f0f6e8-d5ce-4791-a222-e7a0df638810',
+    chatId: chat.id,
+    seq: 1,
+    role: 'user',
+    senderUserId: 'verified-user',
+    parts: [{ type: 'text', text: 'Hello' }],
+    attachments: [],
+    usage: null,
+    inReplyTo: null,
+    createdAt: new Date('2026-06-29T00:01:00.000Z'),
+  },
+  {
+    id: 'cc5ce18b-2f3a-4f6b-8c95-f9c6240a8f02',
+    chatId: chat.id,
+    seq: 2,
+    role: 'assistant',
+    senderUserId: null,
+    parts: [{ type: 'text', text: 'Hi' }],
+    attachments: [],
+    usage: { status: 'completed', finishReason: 'stop' },
+    inReplyTo: '65f0f6e8-d5ce-4791-a222-e7a0df638810',
+    createdAt: new Date('2026-06-29T00:01:01.000Z'),
+  },
+];
 
 describe('ChatsController', () => {
   function makeWritableResponse(): ExpressResponse {
@@ -39,6 +66,7 @@ describe('ChatsController', () => {
     const chatsService = {
       getChatsByUserId: jest.fn().mockResolvedValue([chat]),
       getChatById: jest.fn().mockResolvedValue(chat),
+      getChatMessages: jest.fn().mockResolvedValue(chatMessages),
       updateChat: jest.fn().mockResolvedValue(chat),
       ...service,
     } as unknown as jest.Mocked<ChatsService>;
@@ -59,6 +87,65 @@ describe('ChatsController', () => {
     await controller.getChats('verified-user');
 
     expect(chatsService.getChatsByUserId).toHaveBeenCalledWith('verified-user');
+  });
+
+  it('reads chat messages for the verified user only', async () => {
+    const { controller, chatsService } = makeController();
+
+    const result = await controller.getChatMessages('verified-user', chat.id);
+
+    expect(chatsService.getChatMessages).toHaveBeenCalledWith(
+      chat.id,
+      'verified-user',
+    );
+    expect(result).toEqual({
+      messages: [
+        {
+          id: chatMessages[0].id,
+          chatId: chat.id,
+          seq: 1,
+          role: 'user',
+          senderUserId: 'verified-user',
+          parts: [{ type: 'text', text: 'Hello' }],
+          attachments: [],
+          usage: null,
+          inReplyTo: null,
+          createdAt: new Date('2026-06-29T00:01:00.000Z'),
+        },
+        {
+          id: chatMessages[1].id,
+          chatId: chat.id,
+          seq: 2,
+          role: 'assistant',
+          senderUserId: null,
+          parts: [{ type: 'text', text: 'Hi' }],
+          attachments: [],
+          usage: { status: 'completed', finishReason: 'stop' },
+          inReplyTo: chatMessages[0].id,
+          createdAt: new Date('2026-06-29T00:01:01.000Z'),
+        },
+      ],
+    });
+  });
+
+  it('returns 404 when the verified user cannot read chat messages', async () => {
+    const { controller } = makeController({
+      getChatMessages: jest.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(
+      controller.getChatMessages('verified-user', chat.id),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('returns an empty message list for an owned chat with no messages', async () => {
+    const { controller } = makeController({
+      getChatMessages: jest.fn().mockResolvedValue([]),
+    });
+
+    await expect(
+      controller.getChatMessages('verified-user', chat.id),
+    ).resolves.toEqual({ messages: [] });
   });
 
   it('patches a chat scoped to the verified user only', async () => {

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -37,8 +37,10 @@ import { SessionAuthGuard } from '../auth/session-auth.guard';
 import { ChatLoopService } from './chat-loop.service';
 import { ChatsService } from './chats.service';
 import {
+  ChatMessagesResponse,
   ChatResponse,
   CreateMessageDto,
+  toChatMessageResponse,
   toChatResponse,
   UpdateChatDto,
 } from './dto/chats.dto';
@@ -82,6 +84,24 @@ export class ChatsController {
     }
 
     return toChatResponse(chat);
+  }
+
+  @Get(':id/messages')
+  @ApiParam({ name: 'id', format: 'uuid' })
+  @ApiOkResponse({ type: ChatMessagesResponse })
+  @ApiBadRequestResponse({ description: 'Malformed chat id (not a UUID)' })
+  @ApiNotFoundResponse({ description: 'Chat not found or not owned' })
+  @ApiUnauthorizedResponse()
+  async getChatMessages(
+    @CurrentUser() userId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<ChatMessagesResponse> {
+    const messages = await this.chatsService.getChatMessages(id, userId);
+    if (!messages) {
+      throw new NotFoundException(`Chat ${id} not found`);
+    }
+
+    return { messages: messages.map(toChatMessageResponse) };
   }
 
   // Create-or-append (#86): posting the first message to a not-yet-existing chat id creates

--- a/apps/api/src/chats/chats.controller.ts
+++ b/apps/api/src/chats/chats.controller.ts
@@ -11,6 +11,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   Req,
   Res,
   UseGuards,
@@ -37,6 +38,7 @@ import { SessionAuthGuard } from '../auth/session-auth.guard';
 import { ChatLoopService } from './chat-loop.service';
 import { ChatsService } from './chats.service';
 import {
+  ChatMessagesQueryDto,
   ChatMessagesResponse,
   ChatResponse,
   CreateMessageDto,
@@ -89,14 +91,20 @@ export class ChatsController {
   @Get(':id/messages')
   @ApiParam({ name: 'id', format: 'uuid' })
   @ApiOkResponse({ type: ChatMessagesResponse })
-  @ApiBadRequestResponse({ description: 'Malformed chat id (not a UUID)' })
+  @ApiBadRequestResponse({
+    description: 'Malformed chat id or invalid history pagination query',
+  })
   @ApiNotFoundResponse({ description: 'Chat not found or not owned' })
   @ApiUnauthorizedResponse()
   async getChatMessages(
     @CurrentUser() userId: string,
     @Param('id', ParseUUIDPipe) id: string,
+    @Query() query: ChatMessagesQueryDto,
   ): Promise<ChatMessagesResponse> {
-    const messages = await this.chatsService.getChatMessages(id, userId);
+    const messages = await this.chatsService.getChatMessages(id, userId, {
+      limit: query.limit,
+      beforeSeq: query.beforeSeq,
+    });
     if (!messages) {
       throw new NotFoundException(`Chat ${id} not found`);
     }

--- a/apps/api/src/chats/chats.service.ts
+++ b/apps/api/src/chats/chats.service.ts
@@ -25,6 +25,7 @@ export class ChatsService {
   async getChatMessages(
     chatId: string,
     ownerUserId: string,
+    options: { limit: number; beforeSeq?: number },
   ): Promise<Message[] | undefined> {
     return this.tenantDb.runAs(ownerUserId, async (tx) => {
       const chatsRepository = new ChatsRepository(tx);
@@ -33,7 +34,11 @@ export class ChatsService {
         return undefined;
       }
 
-      return new MessagesRepository(tx).findByChatId(chatId, ownerUserId);
+      return new MessagesRepository(tx).findByChatId(chatId, ownerUserId, {
+        limit: options.limit,
+        maxSeq:
+          options.beforeSeq === undefined ? undefined : options.beforeSeq - 1,
+      });
     });
   }
 

--- a/apps/api/src/chats/chats.service.ts
+++ b/apps/api/src/chats/chats.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { type Chat } from '../db/schema';
+import { type Chat, type Message } from '../db/schema';
 import { TenantDbService } from '../db/tenant-db.service';
-import { ChatsRepository } from './chats-repository';
+import { ChatsRepository, MessagesRepository } from './chats-repository';
 
 @Injectable()
 export class ChatsService {
@@ -20,6 +20,21 @@ export class ChatsService {
     return this.tenantDb.runAs(ownerUserId, (tx) =>
       new ChatsRepository(tx).findById(chatId, ownerUserId),
     );
+  }
+
+  async getChatMessages(
+    chatId: string,
+    ownerUserId: string,
+  ): Promise<Message[] | undefined> {
+    return this.tenantDb.runAs(ownerUserId, async (tx) => {
+      const chatsRepository = new ChatsRepository(tx);
+      const chat = await chatsRepository.findById(chatId, ownerUserId);
+      if (!chat) {
+        return undefined;
+      }
+
+      return new MessagesRepository(tx).findByChatId(chatId, ownerUserId);
+    });
   }
 
   async createChat(input: {

--- a/apps/api/src/chats/dto/chats.dto.spec.ts
+++ b/apps/api/src/chats/dto/chats.dto.spec.ts
@@ -12,6 +12,17 @@ describe('ChatMessagesQueryDto', () => {
     metatype: ChatMessagesQueryDto,
   };
 
+  it('accepts the maximum safe beforeSeq cursor', async () => {
+    await expect(
+      pipe.transform(
+        {
+          beforeSeq: String(Number.MAX_SAFE_INTEGER),
+        },
+        metadata,
+      ),
+    ).resolves.toMatchObject({ beforeSeq: Number.MAX_SAFE_INTEGER });
+  });
+
   it('rejects unsafe beforeSeq cursors instead of rounding them', async () => {
     await expect(
       pipe.transform(
@@ -22,4 +33,13 @@ describe('ChatMessagesQueryDto', () => {
       ),
     ).rejects.toMatchObject({ status: 400 });
   });
+
+  it.each(['9007199254740991.1', '9007199254740990.9'])(
+    'rejects non-integer beforeSeq cursor %s instead of rounding it',
+    async (beforeSeq) => {
+      await expect(
+        pipe.transform({ beforeSeq }, metadata),
+      ).rejects.toMatchObject({ status: 400 });
+    },
+  );
 });

--- a/apps/api/src/chats/dto/chats.dto.spec.ts
+++ b/apps/api/src/chats/dto/chats.dto.spec.ts
@@ -1,0 +1,25 @@
+import { ArgumentMetadata, ValidationPipe } from '@nestjs/common';
+import { ChatMessagesQueryDto } from './chats.dto';
+
+describe('ChatMessagesQueryDto', () => {
+  const pipe = new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    transform: true,
+  });
+  const metadata: ArgumentMetadata = {
+    type: 'query',
+    metatype: ChatMessagesQueryDto,
+  };
+
+  it('rejects unsafe beforeSeq cursors instead of rounding them', async () => {
+    await expect(
+      pipe.transform(
+        {
+          beforeSeq: '9007199254740993',
+        },
+        metadata,
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/api/src/chats/dto/chats.dto.ts
+++ b/apps/api/src/chats/dto/chats.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   ArrayMaxSize,
   ArrayMinSize,
@@ -22,6 +22,25 @@ import type { Chat, Message, MessageRole } from '../../db/schema';
 export const CHAT_MESSAGES_DEFAULT_LIMIT = 100;
 export const CHAT_MESSAGES_MAX_LIMIT = 200;
 export const CHAT_MESSAGES_MAX_SAFE_SEQ = Number.MAX_SAFE_INTEGER;
+
+const SAFE_INTEGER_QUERY_PATTERN = /^(0|[1-9]\d*)$/;
+
+function parseSafeIntegerQueryValue(value: unknown): unknown {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) ? value : Number.NaN;
+  }
+
+  if (typeof value !== 'string' || !SAFE_INTEGER_QUERY_PATTERN.test(value)) {
+    return Number.NaN;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : Number.NaN;
+}
 
 // PATCH /api/v1/chats/:id — partial update. Every field optional; only provided fields
 // are applied. (Currently title is the only mutable field; new ones go here.)
@@ -129,7 +148,7 @@ export class ChatMessagesQueryDto {
     description: 'Return messages strictly before this sequence number.',
   })
   @IsOptional()
-  @Type(() => Number)
+  @Transform(({ value }) => parseSafeIntegerQueryValue(value))
   @IsInt()
   @Min(1)
   @Max(CHAT_MESSAGES_MAX_SAFE_SEQ)

--- a/apps/api/src/chats/dto/chats.dto.ts
+++ b/apps/api/src/chats/dto/chats.dto.ts
@@ -21,6 +21,7 @@ import type { Chat, Message, MessageRole } from '../../db/schema';
 
 export const CHAT_MESSAGES_DEFAULT_LIMIT = 100;
 export const CHAT_MESSAGES_MAX_LIMIT = 200;
+export const CHAT_MESSAGES_MAX_SAFE_SEQ = Number.MAX_SAFE_INTEGER;
 
 // PATCH /api/v1/chats/:id — partial update. Every field optional; only provided fields
 // are applied. (Currently title is the only mutable field; new ones go here.)
@@ -123,6 +124,7 @@ export class ChatMessagesQueryDto {
   @ApiPropertyOptional({
     type: 'integer',
     minimum: 1,
+    maximum: CHAT_MESSAGES_MAX_SAFE_SEQ,
     format: 'int64',
     description: 'Return messages strictly before this sequence number.',
   })
@@ -130,6 +132,7 @@ export class ChatMessagesQueryDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(CHAT_MESSAGES_MAX_SAFE_SEQ)
   beforeSeq?: number;
 }
 

--- a/apps/api/src/chats/dto/chats.dto.ts
+++ b/apps/api/src/chats/dto/chats.dto.ts
@@ -6,15 +6,21 @@ import {
   IsArray,
   IsDefined,
   IsIn,
+  IsInt,
   IsOptional,
   IsString,
   IsUUID,
   Matches,
+  Max,
   MaxLength,
+  Min,
   MinLength,
   ValidateNested,
 } from 'class-validator';
 import type { Chat, Message, MessageRole } from '../../db/schema';
+
+export const CHAT_MESSAGES_DEFAULT_LIMIT = 100;
+export const CHAT_MESSAGES_MAX_LIMIT = 200;
 
 // PATCH /api/v1/chats/:id — partial update. Every field optional; only provided fields
 // are applied. (Currently title is the only mutable field; new ones go here.)
@@ -96,6 +102,35 @@ export function toChatResponse(chat: Chat): ChatResponse {
     createdAt: chat.createdAt,
     updatedAt: chat.updatedAt,
   };
+}
+
+export class ChatMessagesQueryDto {
+  @ApiPropertyOptional({
+    type: 'integer',
+    format: 'int32',
+    minimum: 1,
+    maximum: CHAT_MESSAGES_MAX_LIMIT,
+    default: CHAT_MESSAGES_DEFAULT_LIMIT,
+    description: 'Maximum number of latest messages to return.',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(CHAT_MESSAGES_MAX_LIMIT)
+  limit: number = CHAT_MESSAGES_DEFAULT_LIMIT;
+
+  @ApiPropertyOptional({
+    type: 'integer',
+    minimum: 1,
+    format: 'int64',
+    description: 'Return messages strictly before this sequence number.',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  beforeSeq?: number;
 }
 
 export class ChatMessageResponse {

--- a/apps/api/src/chats/dto/chats.dto.ts
+++ b/apps/api/src/chats/dto/chats.dto.ts
@@ -187,8 +187,8 @@ export function toChatMessageResponse(message: Message): ChatMessageResponse {
     seq: message.seq,
     role: message.role,
     senderUserId: message.senderUserId,
-    parts: message.parts as unknown[],
-    attachments: message.attachments as unknown[],
+    parts: message.parts,
+    attachments: message.attachments,
     usage:
       message.usage === null
         ? null

--- a/apps/api/src/chats/dto/chats.dto.ts
+++ b/apps/api/src/chats/dto/chats.dto.ts
@@ -14,7 +14,7 @@ import {
   MinLength,
   ValidateNested,
 } from 'class-validator';
-import type { Chat } from '../../db/schema';
+import type { Chat, Message, MessageRole } from '../../db/schema';
 
 // PATCH /api/v1/chats/:id — partial update. Every field optional; only provided fields
 // are applied. (Currently title is the only mutable field; new ones go here.)
@@ -95,5 +95,70 @@ export function toChatResponse(chat: Chat): ChatResponse {
     visibility: chat.visibility,
     createdAt: chat.createdAt,
     updatedAt: chat.updatedAt,
+  };
+}
+
+export class ChatMessageResponse {
+  @ApiProperty({ format: 'uuid' })
+  id!: string;
+
+  @ApiProperty({ format: 'uuid' })
+  chatId!: string;
+
+  @ApiProperty({ type: 'integer', format: 'int64' })
+  seq!: number;
+
+  @ApiProperty({ enum: ['user', 'assistant', 'system', 'tool'] })
+  role!: MessageRole;
+
+  @ApiProperty({ type: String, nullable: true })
+  senderUserId!: string | null;
+
+  @ApiProperty({
+    type: 'array',
+    items: { type: 'object', additionalProperties: true },
+  })
+  parts!: unknown[];
+
+  @ApiProperty({
+    type: 'array',
+    items: { type: 'object', additionalProperties: true },
+  })
+  attachments!: unknown[];
+
+  @ApiProperty({
+    type: 'object',
+    nullable: true,
+    additionalProperties: true,
+  })
+  usage!: Record<string, unknown> | null;
+
+  @ApiProperty({ type: String, format: 'uuid', nullable: true })
+  inReplyTo!: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  createdAt!: Date;
+}
+
+export class ChatMessagesResponse {
+  @ApiProperty({ type: () => [ChatMessageResponse] })
+  messages!: ChatMessageResponse[];
+}
+
+export function toChatMessageResponse(message: Message): ChatMessageResponse {
+  return {
+    id: message.id,
+    chatId: message.chatId,
+    seq: message.seq,
+    role: message.role,
+    senderUserId: message.senderUserId,
+    parts: message.parts as unknown[],
+    attachments: message.attachments as unknown[],
+    usage:
+      message.usage === null
+        ? null
+        : (message.usage as Record<string, unknown>),
+    inReplyTo: message.inReplyTo,
+    createdAt: message.createdAt,
   };
 }

--- a/apps/api/src/db/schema/chats.ts
+++ b/apps/api/src/db/schema/chats.ts
@@ -90,8 +90,9 @@ export const messages = pgTable(
     senderUserId: text('sender_user_id').references(() => users.id, {
       onDelete: 'set null',
     }),
-    parts: jsonb('parts').notNull(), // AI SDK v6 UIMessage parts array
+    parts: jsonb('parts').$type<unknown[]>().notNull(), // AI SDK v6 UIMessage parts array
     attachments: jsonb('attachments')
+      .$type<unknown[]>()
       .notNull()
       .default(sql`'[]'::jsonb`),
     usage: jsonb('usage'),

--- a/apps/api/test/chats-messages.e2e-spec.ts
+++ b/apps/api/test/chats-messages.e2e-spec.ts
@@ -358,6 +358,86 @@ d('POST /api/v1/chats/:id/messages — streaming loop', () => {
     models.client.delayMs = 0;
   });
 
+  it('reads persisted message history over guarded HTTP and hides it cross-tenant', async () => {
+    const historyChatId = await createChat(userAId, 'History API Chat');
+    const userMessageId = crypto.randomUUID();
+    let assistantMessageId = '';
+
+    await tenantDb.runAs(userAId, async (tx) => {
+      const messagesRepo = new MessagesRepository(tx);
+      await messagesRepo.create({
+        id: userMessageId,
+        chatId: historyChatId,
+        role: 'user',
+        senderUserId: userAId,
+        parts: [{ type: 'text', text: 'History prompt' }],
+        attachments: [{ type: 'file', name: 'context.txt' }],
+      });
+      const assistantMessage = await messagesRepo.create({
+        chatId: historyChatId,
+        role: 'assistant',
+        senderUserId: null,
+        parts: [{ type: 'text', text: 'History answer' }],
+        attachments: [],
+        usage: { status: 'completed', cachedInputTokens: 1 },
+        inReplyTo: userMessageId,
+      });
+      assistantMessageId = assistantMessage.id;
+    });
+
+    const ownerRead = await request(http)
+      .get(`/api/v1/chats/${historyChatId}/messages`)
+      .set('Cookie', cookieA);
+    const ownerReadBody = ownerRead.body as {
+      messages: Array<{ createdAt: string; seq: number }>;
+    };
+
+    expect(ownerRead.status).toBe(200);
+    expect(ownerReadBody).toEqual({
+      messages: [
+        expect.objectContaining({
+          id: userMessageId,
+          chatId: historyChatId,
+          seq: expect.any(Number),
+          role: 'user',
+          senderUserId: userAId,
+          parts: [{ type: 'text', text: 'History prompt' }],
+          attachments: [{ type: 'file', name: 'context.txt' }],
+          usage: null,
+          inReplyTo: null,
+          createdAt: expect.any(String),
+        }),
+        expect.objectContaining({
+          id: assistantMessageId,
+          chatId: historyChatId,
+          seq: expect.any(Number),
+          role: 'assistant',
+          senderUserId: null,
+          parts: [{ type: 'text', text: 'History answer' }],
+          attachments: [],
+          usage: { status: 'completed', cachedInputTokens: 1 },
+          inReplyTo: userMessageId,
+          createdAt: expect.any(String),
+        }),
+      ],
+    });
+    expect(Date.parse(ownerReadBody.messages[0].createdAt)).not.toBeNaN();
+    expect(Date.parse(ownerReadBody.messages[1].createdAt)).not.toBeNaN();
+    expect(ownerReadBody.messages[0].seq).toBeLessThan(
+      ownerReadBody.messages[1].seq,
+    );
+
+    const crossTenantRead = await request(http)
+      .get(`/api/v1/chats/${historyChatId}/messages`)
+      .set('Cookie', cookieB);
+    expect(crossTenantRead.status).toBe(404);
+
+    const anonymousRead = await request(http).get(
+      `/api/v1/chats/${historyChatId}/messages`,
+    );
+    expect(anonymousRead.status).toBe(401);
+  });
+
   it('streams a UI-message SSE reply and persists user + assistant with usage', async () => {
     const telemetryLog = jest
       .spyOn(turnTelemetryLogger, 'info')

--- a/apps/api/test/chats-messages.e2e-spec.ts
+++ b/apps/api/test/chats-messages.e2e-spec.ts
@@ -427,6 +427,26 @@ d('POST /api/v1/chats/:id/messages — streaming loop', () => {
       ownerReadBody.messages[1].seq,
     );
 
+    const olderPage = await request(http)
+      .get(`/api/v1/chats/${historyChatId}/messages`)
+      .query({ limit: 1, beforeSeq: ownerReadBody.messages[1].seq })
+      .set('Cookie', cookieA);
+    expect(olderPage.status).toBe(200);
+    expect(olderPage.body).toEqual({
+      messages: [
+        expect.objectContaining({
+          id: userMessageId,
+          seq: ownerReadBody.messages[0].seq,
+        }),
+      ],
+    });
+
+    const tooLarge = await request(http)
+      .get(`/api/v1/chats/${historyChatId}/messages`)
+      .query({ limit: 201 })
+      .set('Cookie', cookieA);
+    expect(tooLarge.status).toBe(400);
+
     const crossTenantRead = await request(http)
       .get(`/api/v1/chats/${historyChatId}/messages`)
       .set('Cookie', cookieB);
@@ -436,6 +456,44 @@ d('POST /api/v1/chats/:id/messages — streaming loop', () => {
       `/api/v1/chats/${historyChatId}/messages`,
     );
     expect(anonymousRead.status).toBe(401);
+  });
+
+  it('caps default HTTP message history reads at the latest 100 messages', async () => {
+    const cappedChatId = await createChat(userAId, 'Capped History API Chat');
+    const seededMessageIds: string[] = [];
+
+    await tenantDb.runAs(userAId, async (tx) => {
+      const messagesRepo = new MessagesRepository(tx);
+      for (let index = 0; index < 101; index += 1) {
+        const id = crypto.randomUUID();
+        seededMessageIds.push(id);
+        await messagesRepo.create({
+          id,
+          chatId: cappedChatId,
+          role: 'user',
+          senderUserId: userAId,
+          parts: [{ type: 'text', text: `History prompt ${index}` }],
+        });
+      }
+    });
+
+    const ownerRead = await request(http)
+      .get(`/api/v1/chats/${cappedChatId}/messages`)
+      .set('Cookie', cookieA);
+    const ownerReadBody = ownerRead.body as {
+      messages: Array<{ id: string; seq: number }>;
+    };
+
+    expect(ownerRead.status).toBe(200);
+    expect(ownerReadBody.messages).toHaveLength(100);
+    expect(ownerReadBody.messages.map((message) => message.id)).toEqual(
+      seededMessageIds.slice(1),
+    );
+    expect(
+      ownerReadBody.messages.every((message, index, messages) =>
+        index === 0 ? true : messages[index - 1].seq < message.seq,
+      ),
+    ).toBe(true);
   });
 
   it('streams a UI-message SSE reply and persists user + assistant with usage', async () => {


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/chats/:id/messages` for owner-scoped chat history reads.
- Returns persisted message fields through explicit DTOs and regenerated `apps/api/openapi.json`.
- Covers controller behavior, service/RLS isolation, and live HTTP 200/401/404 behavior.
- Hardens `apps/api/scripts/rls-test.sh` to wait/provision over TCP so the Docker Postgres readiness check targets the final server, not the entrypoint's transient socket startup.

## References

- Tracks #96.
- Unblocks the first API prerequisite slice for #77 / #80 follow-up chat hydration work.

## Verification

- `pnpm --filter api exec tsc --noEmit --pretty false --listFiles false`
- `pnpm --filter api lint`
- `pnpm --filter api test`
- `pnpm --filter api build`
- `bash -n apps/api/scripts/rls-test.sh`
- `pnpm exec prettier --check apps/api/src/chats/chats-rls.integration.spec.ts apps/api/src/chats/chats.controller.spec.ts apps/api/src/chats/chats.controller.ts apps/api/src/chats/chats.service.ts apps/api/src/chats/dto/chats.dto.ts apps/api/test/chats-messages.e2e-spec.ts`
- `apps/api/scripts/rls-test.sh`

## Notes

- The e2e suite still emits existing intentional error logs for telemetry-sink and abort-path tests, plus Jest's existing forced-exit warning, but the fixed RLS gate exits 0.
- `apps/api/src/models/openai-model-client.ts` has an unrelated unstaged local edit and is intentionally excluded from this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GET /api/v1/chats/:id/messages` to read owner-scoped chat history with pagination, caps, and strict cursor validation. Regenerates OpenAPI, expands tests, and hardens Postgres RLS readiness and schema typing; addresses #96 and unblocks #77/#80.

- **New Features**
  - New `GET /api/v1/chats/:id/messages` with 200/400/401/404 responses for owner-only reads.
  - Pagination via `limit` (default 100, max 200) and `beforeSeq` to page backward; returns latest messages in order.
  - Message fields: `id`, `chatId`, `seq`, `role`, `senderUserId`, `parts`, `attachments`, `usage`, `inReplyTo`, `createdAt`.

- **Bug Fixes**
  - Strict integer-only parsing for `beforeSeq`; rejects decimals and values > JS max safe int instead of coercing.
  - `apps/api/scripts/rls-test.sh`: connect over TCP and set `PGPASSWORD` to avoid transient socket issues.
  - Typed message JSON arrays (`parts`, `attachments` as `unknown[]`) to align with DTOs/OpenAPI and prevent shape mismatches.

<sup>Written for commit dd1c4457e0bf835a4d968a68273ab80fb02994f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new chat history endpoint so users can view messages from a specific chat.
  * Chat message responses now include message details such as sender info, attachments, replies, and timestamps.

* **Bug Fixes**
  * Improved access handling for chat history, returning the correct error when a chat isn’t available.
  * Strengthened cross-user and unauthenticated access protection for message history.

* **Tests**
  * Added coverage for message history behavior in both service and end-to-end flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->