### PR TITLE
feat(infra): test CI (#70)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+# Test CI (#70) — gate PRs on the checks that already pass locally:
+# lint / build / unit tests across the workspace, plus apps/api/scripts/rls-test.sh
+# (cross-tenant RLS isolation + the auth/chat e2e over real HTTP against a
+# throwaway Postgres — same script as local, GitHub-hosted runners have Docker).
+#
+# Actions are pinned to commit SHAs (comment = the release tag they resolve to).
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+env:
+  TURBO_TELEMETRY_DISABLED: '1'
+
+jobs:
+  checks:
+    name: lint · build · unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        # version comes from package.json "packageManager"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec turbo run lint
+
+      - run: pnpm exec turbo run build
+
+      # Unit tests (apps/api). DB-backed suites self-skip without POSTGRES_URL /
+      # TEST_DATABASE_URL; model evals stay opt-in behind RUN_MODEL_EVALS.
+      - run: pnpm --filter api test
+
+  rls:
+    name: RLS isolation + e2e (real Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Proves FORCE RLS cross-tenant isolation and runs the HTTP e2e suites
+      # against a throwaway Postgres owned by a non-superuser role — the same
+      # worst-case single-role deployment the script exercises locally.
+      - run: bash apps/api/scripts/rls-test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
 
       - run: pnpm exec turbo run build
 
+      - run: git diff --exit-code
+
       # Unit tests (apps/api). DB-backed suites self-skip without POSTGRES_URL /
       # TEST_DATABASE_URL; model evals stay opt-in behind RUN_MODEL_EVALS.
       - run: pnpm --filter api test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 _Reverse-chronological record of shipped work — features, fixes, and chores. Newest first._
 
+# 2026-07-02
+
+- Added test CI (#70): a GitHub Actions workflow gates every PR (and pushes to `master`) on `turbo run lint`, `turbo run build`, the api unit suite, and `apps/api/scripts/rls-test.sh` — the cross-tenant RLS proof and HTTP e2e against a throwaway Postgres, same script as local. Actions are SHA-pinned, `permissions: contents: read`, actionlint + zizmor clean. Standing up root lint surfaced that `packages/ui`'s lint had been silently broken forever (no `eslint` devDependency) — fixed, along with the three warnings it had been hiding.
+
 # 2026-07-01
 
 - Added per-chat deep links for the web chat (#77): `/chat/[id]` now server-loads persisted history through `apps/api`, sidebar chat rows navigate to stable chat URLs, New Chat resets to `/` with a fresh draft id, and SSR history reads are bounded by a short timeout instead of waiting indefinitely on a stalled API.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "^19",
     "@workspace/config-eslint": "workspace:*",
     "@workspace/config-typescript": "workspace:*",
+    "eslint": "^9.20.1",
     "tailwindcss": "^4.0.8",
     "typescript": "^5.7.3"
   },

--- a/packages/ui/src/components/code-block.tsx
+++ b/packages/ui/src/components/code-block.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@workspace/ui/lib/utils"
 import React, { useEffect, useState } from "react"
-import { codeToHtml, bundledLanguages, bundledLanguagesAlias, bundledLanguagesBase, bundledLanguagesInfo } from "shiki"
+import { codeToHtml, bundledLanguages, bundledLanguagesAlias, bundledLanguagesBase } from "shiki"
 
 const isLanguageSupported = (lang: string): boolean => {
   return (

--- a/packages/ui/types/ua-client-hints.d.ts
+++ b/packages/ui/types/ua-client-hints.d.ts
@@ -1,6 +1,10 @@
 // WICG Spec: https://wicg.github.io/ua-client-hints
 
+// Empty bodies are the point: declaration merging adds NavigatorUA onto the
+// built-in globals — a type alias cannot merge into lib.dom's interfaces.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 declare interface Navigator extends NavigatorUA {}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 declare interface WorkerNavigator extends NavigatorUA {}
 
 // https://wicg.github.io/ua-client-hints/#navigatorua

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       '@workspace/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      eslint:
+        specifier: ^9.20.1
+        version: 9.20.1(jiti@2.4.2)
       tailwindcss:
         specifier: ^4.0.8
         version: 4.0.8


### PR DESCRIPTION
Summary
- Adds GitHub Actions CI for PRs: workspace lint, build, API unit tests, and the RLS/e2e script.
- Includes the small UI lint cleanup needed to make the new CI gate meaningful.

Issues
- Closes #70 when this stack reaches master.

Deferred in later stack PRs
- Product changes from #101 are intentionally left for the following stacked branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements #70 by adding SHA-pinned GitHub Actions CI that gates PRs and `master` on workspace lint/build/API unit tests and the RLS + HTTP e2e script. Also fixes `packages/ui` lint and makes checks fail if builds rewrite tracked files.

- **New Features**
  - Two jobs: checks (`turbo run lint`, `turbo run build`, `git diff --exit-code`, `pnpm --filter api test`) and RLS (`apps/api/scripts/rls-test.sh`).
  - Runs on PRs and `master`; actions pinned to SHAs; `permissions: contents: read`; `persist-credentials: false`.
  - DB-backed tests self-skip without `POSTGRES_URL`; model evals stay off without `RUN_MODEL_EVALS`.

- **Bug Fixes**
  - Add `eslint` to `packages/ui` devDependencies and update `pnpm-lock.yaml`.
  - Fix lint warnings: remove unused `shiki` import; annotate empty merging interfaces in `ua-client-hints.d.ts`.

<sup>Written for commit 66965210eef9cbe250b43b8084a928f65816dcb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated CI checks on pull requests and main-branch pushes.
  * Runs linting, builds, unit tests, and end-to-end database isolation checks in a clean environment.
  * Verifies the repository stays unchanged after the build and test steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->