### PR TITLE
fix(api): exact SQL/helper agreement on turn completion; env-key order

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -44,6 +44,6 @@ COMPACTION_TOKEN_THRESHOLD=
 # heartbeat is re-checked later, and a run whose heartbeat is older than
 # RUN_HEARTBEAT_STALE_SECONDS (default 60) is expired. The executing worker
 # stamps the heartbeat every RUN_HEARTBEAT_SECONDS (default 15).
-RUN_TIMEOUT_SECONDS=
-RUN_HEARTBEAT_STALE_SECONDS=
 RUN_HEARTBEAT_SECONDS=
+RUN_HEARTBEAT_STALE_SECONDS=
+RUN_TIMEOUT_SECONDS=

--- a/apps/api/src/chats/chats-repository.ts
+++ b/apps/api/src/chats/chats-repository.ts
@@ -391,10 +391,13 @@ export class MessagesRepository {
           // to aborted) a reply another retry already marked completed. Re-check status in
           // the WHERE so a row that became `completed` no longer matches → the loser updates
           // 0 rows and returns undefined, leaving the completed answer intact.
-          // Same fail-closed semantics as isCompletedAssistantTurn: a row with
-          // MALFORMED/missing usage is treated as completed (immutable) too —
-          // the two layers must never disagree on what "completed" means.
-          sql`(${messages.usage} ->> 'status') is not null and (${messages.usage} ->> 'status') <> 'completed'`,
+          // EXACTLY isCompletedAssistantTurn's semantics — the two layers must
+          // never disagree on what "completed" means. `->` (jsonb) vs `->>`
+          // (text) distinguishes the cases:
+          //   usage not an object / no 'status' key → `->` IS NULL   → immutable
+          //   {status: 'completed'}                 → text match     → immutable
+          //   {status: <anything else, incl. null>} → DISTINCT FROM  → retryable
+          sql`(${messages.usage} -> 'status') is not null and (${messages.usage} ->> 'status') is distinct from 'completed'`,
         ),
       )
       .returning();


### PR DESCRIPTION
Post-merge follow-ups for the two review threads that were still open when #107 merged.

## SQL/helper agreement on turn completion (the substantive one)

`updateAssistantReply`'s atomic guard and `isCompletedAssistantTurn` disagreed on exactly one input — `{status: null}` (key present, JSON null): the helper called the turn retryable while the SQL called it immutable, so such a retry would stream a new reply but silently update 0 rows. The predicate now uses `->` (jsonb) vs `->>` (text) to distinguish key-missing from null-valued and matches the helper exactly:

| usage shape | helper | SQL (before) | SQL (now) |
|---|---|---|---|
| not an object / no `status` key | immutable | immutable | immutable |
| `{status: 'completed'}` | immutable | immutable | immutable |
| `{status: 'aborted'}` etc. | retryable | retryable | retryable |
| `{status: null}` | retryable | **immutable** | retryable |

Nothing writes `{status: null}` today, so this is invariant hygiene, not a live bug.

## Env-key order

`RUN_*` keys in `.env.example` reordered to the env-file linter's convention.

Verified: tsgo + type-aware oxlint + prettier clean, unit 129, full `rls-test.sh` green (RLS 11, queue 8, e2e 33).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the SQL guard with the helper’s completion check to avoid no-op updates when `usage.status` is null. Also reorder `RUN_*` keys in `.env.example` to match the linter’s order.

- **Bug Fixes**
  - Update `updateAssistantReply` WHERE to `(usage -> 'status') IS NOT NULL AND (usage ->> 'status') IS DISTINCT FROM 'completed'`, matching `isCompletedAssistantTurn` and treating `{status: null}` as retryable.

- **Refactors**
  - Reorder `RUN_HEARTBEAT_SECONDS`, `RUN_HEARTBEAT_STALE_SECONDS`, `RUN_TIMEOUT_SECONDS` in `.env.example` to the linter’s convention.

<sup>Written for commit 1948415010a7cb1bf5f13054a02733cdad88e210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

