### PR TITLE
chore(api): rls-test — wait for HOST port reachability, not just internal readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 _Reverse-chronological record of shipped work — features, fixes, and chores. Newest first._
 
+# 2026-07-05
+
+- Hardened `apps/api/scripts/rls-test.sh`'s readiness wait: it now also confirms the published Postgres port is reachable from the **host** (bash `/dev/tcp`), not just that `pg_isready` succeeds inside the container — under WSL2/Docker the host port-forward can lag the container's internal readiness, which previously let the migration step connect too early and hit `CONNECT_TIMEOUT`.
+
 # 2026-07-04
 
 - Fixed `pnpm --filter web dev` in git worktrees after the Next 16/Turbopack upgrade: the script now launches Next from the monorepo root with `apps/web` as the project directory, avoiding Turbopack's mixed-root module graph that made authenticated chat pages fail with `Cannot find module '@workspace/ui/globals.css'` while unauthenticated/login routes still appeared healthy.

--- a/apps/api/scripts/rls-test.sh
+++ b/apps/api/scripts/rls-test.sh
@@ -26,17 +26,32 @@ echo "▶ starting $IMAGE on :$PORT"
 docker run -d --name "$CONTAINER" -e POSTGRES_PASSWORD=postgres \
   -p "${PORT}:5432" "$IMAGE" >/dev/null
 
+# Host-side reachability probe for the readiness loop below. BOTH: postgres
+# accepting INSIDE the container (pg_isready, checked by the caller), AND the
+# published port reachable from the HOST. Under WSL2/Docker the host
+# port-forward can lag the container's internal readiness by seconds under
+# load — checking only `docker exec pg_isready` (internal) let migrate
+# connect from the host too early and hit CONNECT_TIMEOUT. `/dev/tcp` confirms
+# the host can actually reach the port before we proceed. `127.0.0.1` (not
+# `localhost`) matches every other host probe in this script and sidesteps
+# hosts where `localhost` resolves IPv6-first to `::1` (docker's `-p` only
+# publishes on IPv4). `timeout` is GNU coreutils and isn't guaranteed present
+# (e.g. a stock macOS/BSD shell) — fall back to a bare probe there; a
+# connection to a closed/absent localhost port fails near-instantly either
+# way, so the outer 60-iteration loop below still bounds total wait.
+host_reachable() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/${PORT}" >/dev/null 2>&1
+  else
+    bash -c "exec 3<>/dev/tcp/127.0.0.1/${PORT}" >/dev/null 2>&1
+  fi
+}
+
 echo -n "▶ waiting for postgres"
 ready=false
 for _ in $(seq 1 60); do
-  # BOTH: postgres accepting INSIDE the container, AND the published port
-  # reachable from the HOST. Under WSL2/Docker the host port-forward can lag
-  # the container's internal readiness by seconds under load — checking only
-  # `docker exec pg_isready` (internal) let migrate connect from the host too
-  # early and hit CONNECT_TIMEOUT. `/dev/tcp` confirms the host can actually
-  # reach the port before we proceed.
   if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 \
-    && timeout 1 bash -c "exec 3<>/dev/tcp/localhost/${PORT}" >/dev/null 2>&1; then
+    && host_reachable; then
     ready=true; break
   fi
   echo -n "."; sleep 1

--- a/apps/api/scripts/rls-test.sh
+++ b/apps/api/scripts/rls-test.sh
@@ -29,7 +29,16 @@ docker run -d --name "$CONTAINER" -e POSTGRES_PASSWORD=postgres \
 echo -n "▶ waiting for postgres"
 ready=false
 for _ in $(seq 1 60); do
-  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then ready=true; break; fi
+  # BOTH: postgres accepting INSIDE the container, AND the published port
+  # reachable from the HOST. Under WSL2/Docker the host port-forward can lag
+  # the container's internal readiness by seconds under load — checking only
+  # `docker exec pg_isready` (internal) let migrate connect from the host too
+  # early and hit CONNECT_TIMEOUT. `/dev/tcp` confirms the host can actually
+  # reach the port before we proceed.
+  if docker exec "$CONTAINER" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 \
+    && timeout 1 bash -c "exec 3<>/dev/tcp/localhost/${PORT}" >/dev/null 2>&1; then
+    ready=true; break
+  fi
   echo -n "."; sleep 1
 done
 if [ "$ready" != true ]; then


### PR DESCRIPTION
## What

`apps/api/scripts/rls-test.sh`'s readiness wait only checked `docker exec pg_isready` (Postgres accepting connections **inside** the container). Under WSL2/Docker the host-side published-port forward can lag the container's internal readiness by a few seconds under load, so the very next step — running migrations from the host over `localhost:$PORT` — occasionally connected too early and failed with `write CONNECT_TIMEOUT`, a confusing failure that isn't actually about Postgres being unready.

The readiness loop now additionally requires a real host-side TCP connect (bash `/dev/tcp/localhost/$PORT`) before proceeding, so migrations only start once the port is genuinely reachable from the host, not just from inside the container.

Carved out of `origin/experiment/overnight-loop-3` (single original commit `2277c28`, "chore(api): rls-test — wait for HOST port reachability, not just internal readiness"). Confirmed via diff against current `master` that this fix is not yet present there — `master`'s copy of the script still only checks `pg_isready`.

## Security & tenancy

n/a — this is a test-harness reliability fix with no product surface, auth, or tenancy impact.

## Review findings & refactors

- Full read of the diff at shellcheck rigor (no `shellcheck` binary available in this environment): quoting, variable expansion, and the `timeout`/`/dev/tcp` redirection are correct as written; no changes needed beyond the original patch.
- Confirmed scope: the full delta between master and the carving source for this file also contains an unrelated hunk (running the RLS + queue integration suites serially via `--runInBand`) that belongs to a different, later commit (queue/durable-run infra) — that hunk was deliberately excluded from this PR to keep the slice to exactly one concern.

## Reference comparison

n/a for this slice — it's a local dev/CI harness reliability fix internal to this repo's Postgres-in-Docker bootstrap, with no direct analog worth comparing against the reference checkouts (vercel/ai-chatbot, open-webui, opencode, etc. don't ship an equivalent RLS-proving harness).

## Verification

- Manual review of the script at shellcheck rigor (tool unavailable locally).
- `RLS_TEST_PORT=55441 bash apps/api/scripts/rls-test.sh` — run once, nothing else concurrent: full harness passed — RLS integration suite (13/13), queue integration suite (8/8), and the auth e2e suite (36/39 passed, 3 skipped, 0 failed) all green, port-forward wait included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the readiness wait in `apps/api/scripts/rls-test.sh` to require the Postgres port be reachable from the host before running migrations, preventing early connects and `CONNECT_TIMEOUT` under WSL2/Docker. The probe is now portable (uses `timeout` if available, falls back cleanly) and targets `127.0.0.1` to avoid IPv6 pitfalls.

- **Bug Fixes**
  - Added a host-side TCP probe using `bash` `/dev/tcp/127.0.0.1/$PORT` with a 1s `timeout` when present; falls back to a bare probe if `timeout` is missing.
  - Switched host check from `localhost` to `127.0.0.1` to avoid IPv6-first resolution where Docker’s `-p` publishes IPv4 only.

<sup>Written for commit ad065aa8cac5d526d92065af5304863ca6f45d90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks for the local Postgres-backed workflow so migrations start only when the database is truly reachable, reducing intermittent timeout failures.
* **Chores**
  * Updated the changelog with the latest release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->