### PR TITLE
chore(dev): launch Drizzle Studio with Turbo

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "build": "nest build && node dist/instance-config/prompt-built-runtime.contract.js && node dist/generate-openapi.js && prettier --write --log-level warn openapi.json",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "dev": "nest start --watch",
+    "dev:studio": "drizzle-kit studio",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "preinstall": "npx only-allow@1.2.1 pnpm",
     "prepare": "lefthook install",
     "build": "turbo run build",
-    "dev": "turbo run dev",
+    "dev": "turbo run dev dev:studio",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "test:storybook": "turbo run test:storybook",

--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,10 @@
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "dev:studio": {
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Run Drizzle Studio alongside the existing API, web, and Storybook dev tasks from root `pnpm dev`.
- Add a persistent Turbo `dev:studio` task backed by `drizzle-kit studio`.

## Impact

Developers can start the full local development environment with one command and access Drizzle Studio at `https://local.drizzle.studio`.

## Validation

- `pnpm format:check`
- `git diff --check`
- Turbo dry-run confirmed `api#dev` and `api#dev:studio`.
- Clean `pnpm dev` smoke test reached Web, Storybook, Nest, and Drizzle Studio; the process was stopped by the intentional timeout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Drizzle Studio to the dev workflow so `pnpm dev` starts it alongside API, web, and Storybook. Access Drizzle Studio at https://local.drizzle.studio.

- **New Features**
  - Added `apps/api` `dev:studio` script (`drizzle-kit studio`).
  - Updated root `dev` to run `dev` and `dev:studio` with `turbo`.
  - Declared `dev:studio` in `turbo.json` as persistent with no cache.

<sup>Written for commit b692eeb60985f284982fd59dca9302c0ed1d9a82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

