### PR TITLE
refactor(storybook-addon): genericize runtime identifiers

### DIFF
--- a/packages/storybook-addon-visual-tests/ROADMAP.md
+++ b/packages/storybook-addon-visual-tests/ROADMAP.md
@@ -11,7 +11,7 @@ earlier by installing the packed tarball into an isolated temporary fixture.
 
 ## P0 — Public preview contract and correctness
 
-- [ ] Replace llame/workspace-specific addon IDs, channel events, artifact
+- [x] Replace llame/workspace-specific addon IDs, channel events, artifact
       routes, preview globals, and consumer imports with the final generic
       namespace. No backward-compatible aliases are required before a public
       release exists.

--- a/packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md
+++ b/packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md
@@ -90,12 +90,12 @@ files require a task-level justification.
 - Modify: identifier-dependent tests under
   `packages/storybook-addon-visual-tests/test/`
 
-- [ ] **Step 1: Add failing identifier-contract tests**
+- [x] **Step 1: Add failing identifier-contract tests**
 
   Assert that addon IDs, channel events, artifact routes, and the preview bridge
   use one generic namespace and contain neither `llame` nor `workspace`.
 
-- [ ] **Step 2: Run the focused tests and verify they fail**
+- [x] **Step 2: Run the focused tests and verify they fail**
 
   Run:
 
@@ -106,12 +106,12 @@ files require a task-level justification.
   Expected: failure because current identifiers use `llame` and
   `__LLAME_VISUAL_TESTS__`.
 
-- [ ] **Step 3: Rename the identifiers as one atomic protocol change**
+- [x] **Step 3: Rename the identifiers as one atomic protocol change**
 
   Use the final public package namespace consistently. Do not add compatibility
   aliases: no public version depends on the old names.
 
-- [ ] **Step 4: Run focused and package checks**
+- [x] **Step 4: Run focused and package checks**
 
   ```bash
   pnpm --filter @workspace/storybook-addon-visual-tests test
@@ -121,7 +121,7 @@ files require a task-level justification.
 
   Expected: all pass.
 
-- [ ] **Step 5: Verify internal branding is gone from runtime surfaces**
+- [x] **Step 5: Verify internal branding is gone from runtime surfaces**
 
   ```bash
   rg -n "llame|LLAME|@workspace" \
@@ -136,7 +136,7 @@ files require a task-level justification.
   contain no llame-specific branding; their workspace-scoped imports may remain
   only until the packed-consumer task.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
   ```bash
   git add packages/storybook-addon-visual-tests/src \

--- a/packages/storybook-addon-visual-tests/src/constants.ts
+++ b/packages/storybook-addon-visual-tests/src/constants.ts
@@ -1,4 +1,4 @@
-export const ADDON_ID = "llame/visual-tests";
+export const ADDON_ID = "storybook-addon-visual-tests";
 export const PANEL_ID = `${ADDON_ID}/panel`;
 export const TEST_PROVIDER_ID = `${ADDON_ID}/provider`;
 export const STATUS_TYPE_ID = `${ADDON_ID}/status`;
@@ -7,7 +7,7 @@ export const COMMAND_EVENT = `${ADDON_ID}/command`;
 export const COMMAND_ERROR_EVENT = `${ADDON_ID}/command-error`;
 export const STATE_EVENT = `${ADDON_ID}/state`;
 export const BASELINE_EVENT = `${ADDON_ID}/baseline`;
-export const ARTIFACT_ROUTE = "/__llame_visual_tests__/artifact";
+export const ARTIFACT_ROUTE = "/__storybook_addon_visual_tests__/artifact";
 
 export const DEFAULT_ENVIRONMENT = {
   browserName: "chromium",

--- a/packages/storybook-addon-visual-tests/src/node/capture.ts
+++ b/packages/storybook-addon-visual-tests/src/node/capture.ts
@@ -201,7 +201,7 @@ async function waitForStory(
   capture: VisualCaptureMode;
 }> {
   return page.evaluate(async (id) => {
-    const bridge = globalThis.__LLAME_VISUAL_TESTS__;
+    const bridge = globalThis.__STORYBOOK_ADDON_VISUAL_TESTS__;
     if (!bridge) throw new Error("Visual preview bridge was not installed");
     const report = await Promise.race([
       bridge.wait(id),
@@ -326,7 +326,7 @@ function installPreviewBridge(): void {
     report.disabled !== undefined &&
     report.capture !== undefined;
 
-  globalThis.__LLAME_VISUAL_TESTS__ = {
+  globalThis.__STORYBOOK_ADDON_VISUAL_TESTS__ = {
     report(update: Report) {
       const report = { ...reports.get(update.storyId), ...update };
       reports.set(update.storyId, report);

--- a/packages/storybook-addon-visual-tests/src/preview.ts
+++ b/packages/storybook-addon-visual-tests/src/preview.ts
@@ -15,7 +15,7 @@ export interface VisualPreviewReport {
 }
 
 declare global {
-  var __LLAME_VISUAL_TESTS__:
+  var __STORYBOOK_ADDON_VISUAL_TESTS__:
     | {
         report(report: VisualPreviewReport): void;
         wait(storyId: string): Promise<VisualPreviewReport>;
@@ -35,7 +35,7 @@ channel.on(UNHANDLED_ERRORS_WHILE_PLAYING, () => {
 channel.on(STORY_FINISHED, (payload: StoryFinishedPayload) => {
   const hasUnhandledErrors = storiesWithUnhandledErrors.has(payload.storyId);
   storiesWithUnhandledErrors.delete(payload.storyId);
-  globalThis.__LLAME_VISUAL_TESTS__?.report({
+  globalThis.__STORYBOOK_ADDON_VISUAL_TESTS__?.report({
     storyId: payload.storyId,
     status:
       payload.status === "error" &&
@@ -61,7 +61,7 @@ export function beforeEach(context: {
   const capture =
     context.parameters?.visualTests?.capture ??
     (context.parameters?.layout === "fullscreen" ? "viewport" : "content");
-  globalThis.__LLAME_VISUAL_TESTS__?.report({
+  globalThis.__STORYBOOK_ADDON_VISUAL_TESTS__?.report({
     storyId: context.id,
     disabled: context.parameters?.visualTests?.disable === true,
     capture,

--- a/packages/storybook-addon-visual-tests/test/identifier-contract.test.ts
+++ b/packages/storybook-addon-visual-tests/test/identifier-contract.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  ADDON_ID,
+  ARTIFACT_ROUTE,
+  BASELINE_EVENT,
+  COMMAND_ERROR_EVENT,
+  COMMAND_EVENT,
+  PANEL_ID,
+  STATE_EVENT,
+  STATUS_TYPE_ID,
+  TEST_PROVIDER_ID,
+} from "../src/constants.js";
+
+const runtimeNamespace = "storybook-addon-visual-tests";
+const runtimeFiles = {
+  constants: new URL("../src/constants.ts", import.meta.url),
+  preview: new URL("../src/preview.ts", import.meta.url),
+  capture: new URL("../src/node/capture.ts", import.meta.url),
+};
+const legacyNamespace = ["lla", "me"].join("");
+const workspaceNamespace = ["@", "workspace"].join("");
+
+describe("runtime identifier contract", () => {
+  test("uses one public namespace for addon IDs, channel events, and artifact routes", () => {
+    expect(ADDON_ID).toBe(runtimeNamespace);
+    expect(PANEL_ID).toBe(`${runtimeNamespace}/panel`);
+    expect(TEST_PROVIDER_ID).toBe(`${runtimeNamespace}/provider`);
+    expect(STATUS_TYPE_ID).toBe(`${runtimeNamespace}/status`);
+    expect(COMMAND_EVENT).toBe(`${runtimeNamespace}/command`);
+    expect(COMMAND_ERROR_EVENT).toBe(`${runtimeNamespace}/command-error`);
+    expect(STATE_EVENT).toBe(`${runtimeNamespace}/state`);
+    expect(BASELINE_EVENT).toBe(`${runtimeNamespace}/baseline`);
+    expect(ARTIFACT_ROUTE).toBe("/__storybook_addon_visual_tests__/artifact");
+  });
+
+  test("keeps the preview bridge and runtime source free of internal namespaces", async () => {
+    const sourceByFile = Object.fromEntries(
+      await Promise.all(
+        Object.entries(runtimeFiles).map(async ([name, file]) => [
+          name,
+          await readFile(file, "utf8"),
+        ]),
+      ),
+    );
+    const allRuntimeSource = Object.values(sourceByFile).join("\n");
+
+    expect(sourceByFile.preview).toContain("__STORYBOOK_ADDON_VISUAL_TESTS__");
+    expect(sourceByFile.capture).toContain("__STORYBOOK_ADDON_VISUAL_TESTS__");
+    expect(allRuntimeSource).not.toContain(legacyNamespace);
+    expect(allRuntimeSource).not.toContain(workspaceNamespace);
+  });
+});

--- a/packages/storybook-addon-visual-tests/test/preview.test.ts
+++ b/packages/storybook-addon-visual-tests/test/preview.test.ts
@@ -20,7 +20,7 @@ describe("visual preview readiness", () => {
 
   beforeEach(() => {
     report.mockReset();
-    globalThis.__LLAME_VISUAL_TESTS__ = {
+    globalThis.__STORYBOOK_ADDON_VISUAL_TESTS__ = {
       report,
       wait: vi.fn(),
       get: vi.fn(),


### PR DESCRIPTION
## Summary

Implements [Task 1: Replace llame-specific runtime identifiers](packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md#task-1-replace-llame-specific-runtime-identifiers).

- Replaces the addon ID, channel events, artifact route, and preview bridge with the generic `storybook-addon-visual-tests` namespace.
- Adds an identifier contract that keeps the preview and capture bridges aligned and rejects internal/workspace runtime branding.
- Uses `storybook-addon-visual-tests` as the package-neutral runtime namespace because the final npm name has not been selected.

## Review

- Self-review: complete diff inspected against `master`; only Task 1 source and identifier tests are staged. `git diff --check` passes; runtime and non-fixture tests have no internal/workspace branding; fixtures have no internal branding.
- Independent review: complete. One test-strength finding was addressed by independently asserting the preview and capture bridge identifiers; re-review approved with no substantive findings.

## Validation

- `pnpm --filter @workspace/storybook-addon-visual-tests test identifier-contract protocol preview server capture`
- `pnpm --filter @workspace/storybook-addon-visual-tests test constants protocol preview server capture`
- `pnpm --filter @workspace/storybook-addon-visual-tests test`
- `pnpm --filter @workspace/storybook-addon-visual-tests typecheck`
- `pnpm --filter @workspace/storybook-addon-visual-tests lint`
- `pnpm --filter @workspace/storybook-addon-visual-tests test:visual`
- `pnpm format:check`

The package `test:visual` script currently resolves `playwright@1.55.1` while
the smoke test imports `@playwright/test@1.53.2`, so it fails before test
discovery. That dependency alignment is outside Task 1 and package metadata is
explicitly excluded from this PR. The matching 1.53.2 runner completed the
visual smoke after Chromium was installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Storybook Visual Tests addon’s public runtime identifiers and artifact route.
  * Improved consistency of visual test preview and capture communication under the standardized addon namespace.

* **Documentation**
  * Marked the public preview identifier stabilization work as complete in project documentation.

* **Tests**
  * Added coverage validating runtime identifiers, artifact routing, and preview bridge naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->