### PR TITLE
fix(storybook-addon): emit diffs only for changed pixels

### DIFF
--- a/packages/storybook-addon-visual-tests/ROADMAP.md
+++ b/packages/storybook-addon-visual-tests/ROADMAP.md
@@ -26,7 +26,7 @@ earlier by installing the packed tarball into an isolated temporary fixture.
 - [x] Separate Node-only runner results from channel-visible results so
       filesystem import paths are neither serialized nor falsely present in
       manager types.
-- [ ] Emit and register a diff artifact only when pixels changed; prevent a
+- [x] Emit and register a diff artifact only when pixels changed; prevent a
       later passing run from exposing a stale diff.
 
 ## P1 — Consumer-visible confidence

--- a/packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md
+++ b/packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md
@@ -204,12 +204,12 @@ files require a task-level justification.
 - Test: `packages/storybook-addon-visual-tests/test/compare.test.ts`
 - Test: `packages/storybook-addon-visual-tests/test/runner.test.ts`
 
-- [ ] **Step 1: Add failing artifact-lifecycle tests**
+- [x] **Step 1: Add failing artifact-lifecycle tests**
 
   Cover pixel-identical passes, changed pixels, metadata-only incompatibility,
   and removal/non-registration of a stale previous diff.
 
-- [ ] **Step 2: Run focused tests and verify failure**
+- [x] **Step 2: Run focused tests and verify failure**
 
   ```bash
   pnpm --filter @workspace/storybook-addon-visual-tests test compare runner
@@ -217,13 +217,21 @@ files require a task-level justification.
 
   Expected: pixel-identical comparisons currently return and register a diff.
 
-- [ ] **Step 3: Emit diffs only for pixel changes**
+- [x] **Step 3: Emit diffs only for pixel changes**
 
   Keep baseline and candidate review available for metadata incompatibility, but
   do not display a zero-information diff. Ensure a later passing run cannot
   expose a stale diff artifact.
 
-- [ ] **Step 4: Run package and Storybook UI verification**
+  Shipped invariant: after a comparison, `diff.png` exists exactly when that
+  comparison produced one. Removal is required rather than merely skipping
+  registration, because `ArtifactRegistry` caches one opaque id per path for
+  the process lifetime, so a stale file stays servable to a retained id. The
+  removal is best effort — non-exposure is guaranteed by not registering the
+  path, so an undeletable file must not downgrade a passing comparison to a
+  capture-error.
+
+- [x] **Step 4: Run package and Storybook UI verification**
 
   Follow the repository Storybook MCP instructions before changing the rendered
   panel. Run the affected story tests and preview the affected panel stories,
@@ -237,7 +245,13 @@ files require a task-level justification.
 
   Expected: all pass; a passing result exposes no Diff tab.
 
-- [ ] **Step 5: Commit**
+  Storybook story tests could not be executed locally (the WSL2 host is missing
+  Playwright's browser system libraries, and nixpkgs' replacements need a newer
+  glibc than the host provides). The affected panel states were instead
+  verified in a real browser against the running Storybook, and CI runs the
+  story tests with `playwright install --with-deps chromium`.
+
+- [x] **Step 5: Commit**
 
   ```bash
   git add packages/storybook-addon-visual-tests/src \

--- a/packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md
+++ b/packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md
@@ -223,13 +223,22 @@ files require a task-level justification.
   do not display a zero-information diff. Ensure a later passing run cannot
   expose a stale diff artifact.
 
-  Shipped invariant: after a comparison, `diff.png` exists exactly when that
-  comparison produced one. Removal is required rather than merely skipping
-  registration, because `ArtifactRegistry` caches one opaque id per path for
-  the process lifetime, so a stale file stays servable to a retained id. The
-  removal is best effort — non-exposure is guaranteed by not registering the
-  path, so an undeletable file must not downgrade a passing comparison to a
-  capture-error.
+  Shipped as two guarantees of deliberately different strength:
+
+  - A result without a diff never exposes or registers one — unconditional.
+    The artifact entry and the `register` call share the same guard, so this
+    does not depend on the filesystem.
+  - The stale bytes become unreachable — best effort. Removal is what makes a
+    diff id issued by an earlier changed run stop resolving, since
+    `ArtifactRegistry` caches one opaque id per path for the process lifetime.
+    If the unlink fails, that older id stays servable until a later run
+    removes the file.
+
+  Removal is best effort by design: because the first guarantee never depended
+  on it, an undeletable file must not downgrade a passing comparison to a
+  capture-error, which the testing widget reports as a failed visual test.
+  Writing a diff still fails loudly, since a changed result registers that path
+  and must not advertise a missing image.
 
 - [x] **Step 4: Run package and Storybook UI verification**
 

--- a/packages/storybook-addon-visual-tests/src/manager/Panel.stories.tsx
+++ b/packages/storybook-addon-visual-tests/src/manager/Panel.stories.tsx
@@ -146,7 +146,9 @@ export const Running: Story = {
 /**
  * Use the passed state to confirm a capture that matched its committed
  * baseline: the summary keeps a rerun affordance (never a stop button) and
- * offers no Accept, since there is nothing to approve.
+ * offers no Accept, since there is nothing to approve. A passing comparison
+ * emits no diff, so the Diff tab stays disabled and review falls back to the
+ * latest capture.
  *
  * @summary for a story whose capture matched its baseline
  */
@@ -177,6 +179,55 @@ export const Passed: Story = {
     await expect(
       canvas.getByRole("button", { name: "Run visual tests" }),
     ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Diff" })).toBeDisabled();
+    await expect(
+      canvas.getByRole("button", { name: "Latest" }),
+    ).toHaveAttribute("aria-pressed", "true");
+  },
+};
+
+/**
+ * Use the metadata-only change state when a capture is pixel-identical to its
+ * baseline but the recorded environment no longer matches. The reviewer still
+ * gets the explanation and both images to approve from, but no Diff view —
+ * zero changed pixels would only render an empty one.
+ *
+ * @summary for an environment mismatch with no changed pixels
+ */
+export const MetadataOnlyChange: Story = {
+  tags: ["ai-generated"],
+  args: {
+    currentStoryId: "button--primary",
+    state: {
+      runId: "run-metadata",
+      running: false,
+      results: [
+        {
+          runId: "run-metadata",
+          storyId: "button--primary",
+          title: "Button / Primary",
+          environmentKey: "chromium-1280x720@1x",
+          status: "changed",
+          message:
+            "Baseline environment metadata is incompatible with the candidate",
+          diffPixels: 0,
+          candidateSha256: "a".repeat(64),
+          artifacts: { baseline: "baseline", candidate: "candidate" },
+        },
+      ],
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText("Changed")).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/Baseline environment metadata is incompatible/),
+    ).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Diff" })).toBeDisabled();
+    await expect(
+      canvas.getByRole("button", { name: "Latest" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    // Zero changed pixels must not cost the reviewer their approval path.
+    await expect(canvas.getByRole("button", { name: /Accept/ })).toBeEnabled();
   },
 };
 

--- a/packages/storybook-addon-visual-tests/src/node/compare.ts
+++ b/packages/storybook-addon-visual-tests/src/node/compare.ts
@@ -80,7 +80,9 @@ export function comparePngs(options: ComparePngsOptions): ComparisonResult {
     ...(message ? { message } : {}),
     baselineSha256,
     candidateSha256,
-    diff: PNG.sync.write(diff),
+    // A diff of zero changed pixels shows nothing; a metadata-only change
+    // stays reviewable through its message plus baseline and candidate.
+    ...(diffPixels > 0 ? { diff: PNG.sync.write(diff) } : {}),
     diffPixels,
     diffRatio,
     width,

--- a/packages/storybook-addon-visual-tests/src/node/runner.ts
+++ b/packages/storybook-addon-visual-tests/src/node/runner.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { DEFAULT_ENVIRONMENT } from "../constants.js";
@@ -400,9 +400,16 @@ export class VisualTestRunner {
     result.diffRatio = comparison.diffRatio;
     result.candidateSha256 = comparison.candidateSha256;
 
+    // After a comparison, diff.png exists exactly when this comparison
+    // produced one. Deleting is what makes that an invariant rather than a
+    // display rule: the artifact registry hands out one stable id per path
+    // for the process lifetime, so an earlier run's diff id stays servable
+    // until the bytes are gone.
     if (comparison.diff) {
       await mkdir(path.dirname(paths.diffPath), { recursive: true });
       await writeFile(paths.diffPath, comparison.diff);
+    } else {
+      await rm(paths.diffPath, { force: true });
     }
     result.artifacts = {
       ...(baseline && this.options.artifactRegistry

--- a/packages/storybook-addon-visual-tests/src/node/runner.ts
+++ b/packages/storybook-addon-visual-tests/src/node/runner.ts
@@ -400,16 +400,21 @@ export class VisualTestRunner {
     result.diffRatio = comparison.diffRatio;
     result.candidateSha256 = comparison.candidateSha256;
 
-    // After a comparison, diff.png exists exactly when this comparison
-    // produced one. Deleting is what makes that an invariant rather than a
-    // display rule: the artifact registry hands out one stable id per path
-    // for the process lifetime, so an earlier run's diff id stays servable
-    // until the bytes are gone.
+    // Writing the diff is load-bearing — a changed result registers this path,
+    // so a failed write must fail the story rather than advertise an image
+    // that is missing or stale.
     if (comparison.diff) {
       await mkdir(path.dirname(paths.diffPath), { recursive: true });
       await writeFile(paths.diffPath, comparison.diff);
     } else {
-      await rm(paths.diffPath, { force: true });
+      // Removing an earlier run's diff is best effort. It matters because the
+      // artifact registry hands out one stable id per path for the process
+      // lifetime, so a stale file stays servable to anyone still holding that
+      // id. But non-exposure is already guaranteed below by not registering
+      // the path at all, so a locked or read-only file must not downgrade a
+      // genuinely passing comparison to a capture-error — the testing widget
+      // reports that as a failed visual test.
+      await rm(paths.diffPath, { force: true }).catch(() => undefined);
     }
     result.artifacts = {
       ...(baseline && this.options.artifactRegistry

--- a/packages/storybook-addon-visual-tests/src/node/runner.ts
+++ b/packages/storybook-addon-visual-tests/src/node/runner.ts
@@ -414,6 +414,11 @@ export class VisualTestRunner {
       // the path at all, so a locked or read-only file must not downgrade a
       // genuinely passing comparison to a capture-error — the testing widget
       // reports that as a failed visual test.
+      //
+      // The tradeoff is that a persistent failure here is silent, since the
+      // addon has nowhere to report it; a retained id would keep serving the
+      // stale image until some later run manages the removal. Revisit if this
+      // ever gets a logging surface.
       await rm(paths.diffPath, { force: true }).catch(() => undefined);
     }
     result.artifacts = {

--- a/packages/storybook-addon-visual-tests/test/compare.test.ts
+++ b/packages/storybook-addon-visual-tests/test/compare.test.ts
@@ -51,25 +51,37 @@ describe("comparePngs", () => {
   });
 
   test("passes identical pixels with compatible metadata", () => {
-    expect(
-      comparePngs({
-        baseline: black,
-        baselineMetadata: metadata(black),
-        candidate: black,
-        candidateMetadata: metadata(black),
-      }),
-    ).toMatchObject({ status: "passed", diffPixels: 0, diffRatio: 0 });
+    const result = comparePngs({
+      baseline: black,
+      baselineMetadata: metadata(black),
+      candidate: black,
+      candidateMetadata: metadata(black),
+    });
+
+    expect(result).toMatchObject({
+      status: "passed",
+      diffPixels: 0,
+      diffRatio: 0,
+    });
+    // A zero-pixel diff carries no information; emitting one would let the
+    // panel offer a meaningless Diff view for a passing comparison.
+    expect(result.diff).toBeUndefined();
   });
 
   test("treats host platform as provenance for a shared environment key", () => {
-    expect(
-      comparePngs({
-        baseline: black,
-        baselineMetadata: metadata(black, { platform: "darwin" }),
-        candidate: black,
-        candidateMetadata: metadata(black, { platform: "linux" }),
-      }),
-    ).toMatchObject({ status: "passed", diffPixels: 0, diffRatio: 0 });
+    const result = comparePngs({
+      baseline: black,
+      baselineMetadata: metadata(black, { platform: "darwin" }),
+      candidate: black,
+      candidateMetadata: metadata(black, { platform: "linux" }),
+    });
+
+    expect(result).toMatchObject({
+      status: "passed",
+      diffPixels: 0,
+      diffRatio: 0,
+    });
+    expect(result.diff).toBeUndefined();
   });
 
   test("returns a diff when any pixel changes", () => {
@@ -147,6 +159,9 @@ describe("comparePngs", () => {
         diffRatio: 0,
       });
       expect(result.message).toBeTruthy();
+      // The explanatory message plus baseline/candidate review is the whole
+      // signal here — an all-transparent diff would only mislead.
+      expect(result.diff).toBeUndefined();
     },
   );
 
@@ -160,5 +175,6 @@ describe("comparePngs", () => {
 
     expect(result).toMatchObject({ status: "changed", diffPixels: 0 });
     expect(result.message).toMatch(/candidate metadata hash/i);
+    expect(result.diff).toBeUndefined();
   });
 });

--- a/packages/storybook-addon-visual-tests/test/runner.test.ts
+++ b/packages/storybook-addon-visual-tests/test/runner.test.ts
@@ -295,6 +295,44 @@ describe("VisualTestRunner", () => {
     }
   });
 
+  test("keeps a passing result when the stale diff cannot be removed", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "visual-undeletable-"));
+    try {
+      const paths = pathsFor(dir, "alpha--one");
+      await mkdir(paths.directory, { recursive: true });
+      await writeFile(paths.baselinePath, Buffer.from("baseline-png"));
+      // A directory at diff.png makes the non-recursive removal fail with
+      // something other than ENOENT, standing in for the real-world cases
+      // (locked file, read-only mount, permission drift) that `force` does
+      // not suppress.
+      await mkdir(paths.diffPath, { recursive: true });
+
+      const registered: string[] = [];
+      const runner = minimalRunner({
+        captured: [],
+        resolveArtifactPaths: async ({ storyId }) => pathsFor(dir, storyId),
+        artifactRegistry: { register: registerByBasename(registered) },
+        comparePngs: () => passedComparison(),
+      });
+
+      const state = await runner.run({
+        scope: "current",
+        storyId: "alpha--one",
+      });
+
+      // Cleanup is best effort: failing to unlink must not turn a genuinely
+      // passing comparison into a capture-error, which the testing widget
+      // would report as a failed visual test.
+      expect(state.results[0]).toMatchObject({ status: "passed" });
+      expect(state.results[0]?.message).toBeUndefined();
+      // The exposure invariant does not depend on the removal succeeding.
+      expect(state.results[0]?.artifacts?.diff).toBeUndefined();
+      expect(registered).not.toContain(paths.diffPath);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("registers a diff for changed pixels, then deletes it when a later run passes", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "visual-diff-"));
     try {

--- a/packages/storybook-addon-visual-tests/test/runner.test.ts
+++ b/packages/storybook-addon-visual-tests/test/runner.test.ts
@@ -14,6 +14,7 @@ import {
   type ComparisonResult,
 } from "../src/node/compare.js";
 import { VisualTestRunner } from "../src/node/runner.js";
+import { ArtifactRegistry } from "../src/node/server.js";
 
 describe("VisualTestRunner", () => {
   test("discovers exact live story entries and runs at most two captures concurrently", async () => {
@@ -328,6 +329,54 @@ describe("VisualTestRunner", () => {
       // The exposure invariant does not depend on the removal succeeding.
       expect(state.results[0]?.artifacts?.diff).toBeUndefined();
       expect(registered).not.toContain(paths.diffPath);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("kills an earlier run's diff id against the real artifact registry", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "visual-registry-"));
+    try {
+      const paths = pathsFor(dir, "alpha--one");
+      await mkdir(paths.directory, { recursive: true });
+      await writeFile(paths.baselinePath, Buffer.from("baseline-png"));
+
+      // The real registry, not a stub — this test exists because the whole
+      // reason removal beats non-registration is a registry implementation
+      // detail, so stubbing it would assume away the thing under test.
+      const registry = new ArtifactRegistry();
+      let comparison: ComparisonResult = changedComparison(
+        Buffer.from("diff-png"),
+      );
+      const runner = minimalRunner({
+        captured: [],
+        resolveArtifactPaths: async ({ storyId }) => pathsFor(dir, storyId),
+        artifactRegistry: registry,
+        comparePngs: () => comparison,
+      });
+
+      const changed = await runner.run({
+        scope: "current",
+        storyId: "alpha--one",
+      });
+      const leakedId = changed.results[0]!.artifacts!.diff!;
+      expect(registry.resolve(leakedId)).toBe(paths.diffPath);
+
+      comparison = passedComparison();
+      const passed = await runner.run({
+        scope: "current",
+        storyId: "alpha--one",
+      });
+
+      expect(passed.results[0]?.artifacts?.diff).toBeUndefined();
+      // The id itself is immortal: the registry hands out one per path for the
+      // process lifetime, so it still maps to the same path afterwards.
+      expect(registry.resolve(leakedId)).toBe(paths.diffPath);
+      // Removing the bytes is therefore what actually retires it — the
+      // artifact route reads the path and 404s once this read fails.
+      await expect(readFile(registry.resolve(leakedId)!)).rejects.toMatchObject(
+        { code: "ENOENT" },
+      );
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/storybook-addon-visual-tests/test/runner.test.ts
+++ b/packages/storybook-addon-visual-tests/test/runner.test.ts
@@ -1,11 +1,18 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+import { PNG } from "pngjs";
 import type { StoryIndex } from "storybook/internal/types";
 import { describe, expect, test, vi } from "vitest";
 
 import { DEFAULT_ENVIRONMENT } from "../src/constants.js";
+import {
+  COMPARATOR_POLICY,
+  comparePngs,
+  sha256,
+  type ComparisonResult,
+} from "../src/node/compare.js";
 import { VisualTestRunner } from "../src/node/runner.js";
 
 describe("VisualTestRunner", () => {
@@ -288,6 +295,192 @@ describe("VisualTestRunner", () => {
     }
   });
 
+  test("registers a diff for changed pixels, then deletes it when a later run passes", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "visual-diff-"));
+    try {
+      const paths = pathsFor(dir, "alpha--one");
+      await mkdir(paths.directory, { recursive: true });
+      await writeFile(paths.baselinePath, Buffer.from("baseline-png"));
+
+      const registered: string[] = [];
+      let comparison: ComparisonResult = changedComparison(
+        Buffer.from("diff-png"),
+      );
+      const runner = minimalRunner({
+        captured: [],
+        resolveArtifactPaths: async ({ storyId }) => pathsFor(dir, storyId),
+        artifactRegistry: { register: registerByBasename(registered) },
+        comparePngs: () => comparison,
+      });
+
+      const changed = await runner.run({
+        scope: "current",
+        storyId: "alpha--one",
+      });
+
+      expect(changed.results[0]).toMatchObject({ status: "changed" });
+      expect(changed.results[0]?.artifacts).toEqual({
+        baseline: "id:baseline.png",
+        candidate: "id:candidate.png",
+        diff: "id:diff.png",
+      });
+      await expect(readFile(paths.diffPath)).resolves.toEqual(
+        Buffer.from("diff-png"),
+      );
+
+      registered.length = 0;
+      comparison = passedComparison();
+      const passed = await runner.run({
+        scope: "current",
+        storyId: "alpha--one",
+      });
+
+      expect(passed.results[0]).toMatchObject({ status: "passed" });
+      expect(passed.results[0]?.artifacts).toEqual({
+        baseline: "id:baseline.png",
+        candidate: "id:candidate.png",
+      });
+      expect(registered).not.toContain(paths.diffPath);
+      // The stale file is removed, not merely omitted: the registry keeps an
+      // opaque id alive per path for the process lifetime, so leaving the
+      // bytes on disk would keep the earlier run's diff servable.
+      await expect(readFile(paths.diffPath)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps a metadata-only change reviewable and approvable without a diff", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "visual-metadata-"));
+    try {
+      const paths = pathsFor(dir, "alpha--one");
+      await mkdir(paths.directory, { recursive: true });
+      await writeFile(paths.baselinePath, Buffer.from("baseline-png"));
+
+      const registered: string[] = [];
+      const approveCandidate = vi.fn(async (_options: unknown) => ({
+        baselineSha256: "a".repeat(64),
+      }));
+      const runner = minimalRunner({
+        captured: [],
+        approveCandidate,
+        resolveArtifactPaths: async ({ storyId }) => pathsFor(dir, storyId),
+        artifactRegistry: { register: registerByBasename(registered) },
+        comparePngs: () => ({
+          ...passedComparison(),
+          status: "changed" as const,
+          message: "Baseline environment metadata is incompatible",
+        }),
+      });
+
+      const state = await runner.run({
+        scope: "current",
+        storyId: "alpha--one",
+      });
+
+      expect(state.results[0]).toMatchObject({
+        status: "changed",
+        message: "Baseline environment metadata is incompatible",
+        diffPixels: 0,
+      });
+      expect(state.results[0]?.artifacts).toEqual({
+        baseline: "id:baseline.png",
+        candidate: "id:candidate.png",
+      });
+      await expect(readFile(paths.diffPath)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+
+      // Zero changed pixels must not cost the reviewer their approval path.
+      await runner.approve({
+        runId: state.runId!,
+        storyId: "alpha--one",
+        environmentKey: DEFAULT_ENVIRONMENT.key,
+        candidateSha256: "a".repeat(64),
+      });
+      expect(approveCandidate).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  // The tests above inject a fake comparator to drive the artifact wiring.
+  // These two run the real one end to end, so the disk-level invariant is not
+  // only asserted against a mock.
+  test.each([
+    [
+      "a real passing comparison",
+      "136.0",
+      { status: "passed", message: undefined },
+    ],
+    [
+      "a real metadata-only incompatibility",
+      "999.0",
+      {
+        status: "changed",
+        message:
+          "Baseline environment metadata is incompatible with the candidate",
+      },
+    ],
+  ])(
+    "leaves no diff on disk or in the result for %s",
+    async (_name, baselineBrowserVersion, expected) => {
+      const dir = await mkdtemp(path.join(tmpdir(), "visual-real-"));
+      try {
+        const paths = pathsFor(dir, "alpha--one");
+        await mkdir(paths.directory, { recursive: true });
+
+        // Byte-identical baseline and candidate: zero changed pixels.
+        const image = realPng();
+        await writeFile(paths.baselinePath, image);
+        await writeFile(
+          paths.baselineMetadataPath,
+          JSON.stringify(
+            baselineMetadataFor(image, {
+              browserVersion: baselineBrowserVersion,
+            }),
+          ),
+        );
+        // A diff left behind by an earlier changed run.
+        await writeFile(paths.diffPath, Buffer.from("stale-diff-png"));
+
+        const registered: string[] = [];
+        const runner = minimalRunner({
+          captured: [],
+          resolveArtifactPaths: async ({ storyId }) => pathsFor(dir, storyId),
+          artifactRegistry: { register: registerByBasename(registered) },
+          comparePngs: comparePngs,
+          capture: async () => ({
+            status: "captured" as const,
+            image,
+            browserVersion: "136.0",
+            playwrightVersion: "1.53.2",
+          }),
+        });
+
+        const state = await runner.run({
+          scope: "current",
+          storyId: "alpha--one",
+        });
+
+        expect(state.results[0]).toMatchObject({
+          status: expected.status,
+          diffPixels: 0,
+        });
+        expect(state.results[0]?.message).toBe(expected.message);
+        expect(state.results[0]?.artifacts?.diff).toBeUndefined();
+        expect(registered).not.toContain(paths.diffPath);
+        await expect(readFile(paths.diffPath)).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
   test("loadBaseline surfaces a committed baseline without capturing", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "visual-baseline-"));
     try {
@@ -412,6 +605,12 @@ function minimalRunner(options: {
     >
   >;
   approveCandidate?: (...args: any[]) => Promise<any>;
+  artifactRegistry?: ConstructorParameters<
+    typeof VisualTestRunner
+  >[0]["artifactRegistry"];
+  comparePngs?: ConstructorParameters<
+    typeof VisualTestRunner
+  >[0]["comparePngs"];
   resolveArtifactPaths?: ConstructorParameters<
     typeof VisualTestRunner
   >[0]["resolveArtifactPaths"];
@@ -444,16 +643,76 @@ function minimalRunner(options: {
           };
         }),
     }),
-    comparePngs: () => ({
-      status: "new",
-      candidateSha256: "a".repeat(64),
-      diffPixels: 0,
-      diffRatio: 0,
-      width: 1280,
-      height: 720,
-    }),
+    artifactRegistry: options.artifactRegistry,
+    comparePngs:
+      options.comparePngs ??
+      (() => ({
+        status: "new",
+        candidateSha256: "a".repeat(64),
+        diffPixels: 0,
+        diffRatio: 0,
+        width: 1280,
+        height: 720,
+      })),
     approveCandidate: options.approveCandidate as never,
   });
+}
+
+function realPng(): Buffer {
+  const image = new PNG({ width: 2, height: 1 });
+  image.data.set([0, 0, 0, 255], 0);
+  image.data.set([0, 0, 0, 255], 4);
+  return PNG.sync.write(image);
+}
+
+/** Shaped to satisfy the comparator's strict baseline-metadata validation. */
+function baselineMetadataFor(
+  image: Buffer,
+  options: { browserVersion: string },
+) {
+  return {
+    schemaVersion: 1,
+    baselineSha256: sha256(image),
+    browser: {
+      name: DEFAULT_ENVIRONMENT.browserName,
+      version: options.browserVersion,
+      playwrightVersion: "1.53.2",
+    },
+    platform: process.platform,
+    viewport: DEFAULT_ENVIRONMENT.viewport,
+    deviceScaleFactor: DEFAULT_ENVIRONMENT.deviceScaleFactor,
+    comparator: COMPARATOR_POLICY,
+  };
+}
+
+function passedComparison() {
+  return {
+    status: "passed" as const,
+    baselineSha256: "b".repeat(64),
+    candidateSha256: "a".repeat(64),
+    diffPixels: 0,
+    diffRatio: 0,
+    width: 2,
+    height: 1,
+  };
+}
+
+function changedComparison(diff: Buffer) {
+  return {
+    ...passedComparison(),
+    status: "changed" as const,
+    diff,
+    diffPixels: 1,
+    diffRatio: 0.5,
+  };
+}
+
+/** Mirrors the real registry's stable path-to-id mapping, but readably. */
+function registerByBasename(registered: string[]) {
+  return (filePath: string) => {
+    registered.push(filePath);
+    return `id:${path.basename(filePath)}`;
+  };
 }
 
 function pathsFor(root: string, storyId: string) {


### PR DESCRIPTION
Implements **Task 3: Remove misleading passing diff artifacts** from [the public preview release plan](https://github.com/leon0399/llame/blob/master/packages/storybook-addon-visual-tests/docs/2026-07-24-public-preview-release-plan.md#task-3-remove-misleading-passing-diff-artifacts), and ticks off its P0 roadmap entry.

## Behavior before and after

**Before:** `comparePngs` serialized a PNG diff whenever a baseline existed — including when pixelmatch reported **zero** changed pixels. The runner then wrote `diff.png` and registered it as an artifact, so a passing comparison shipped an image whose only content was "nothing changed", and the panel could offer a Diff view for it.

**After:** a diff is emitted only when `diffPixels > 0`.

| Case | Status | Diff |
| --- | --- | --- |
| Pixel-identical, compatible metadata | `passed` | none |
| Changed pixels | `changed` | written + registered |
| Metadata-only incompatibility, 0 changed pixels | `changed` + explanatory message, baseline & candidate still reviewable and approvable | none |

Approval eligibility, comparison status, hashes, path confinement, and the coupled `state.results` / private `completed` stores are unchanged.

## Stale diff-file policy

**The file is removed, not merely left unregistered** — chosen deliberately over the weaker "hidden from the public result" option.

`ArtifactRegistry.register` caches **one opaque id per path for the process lifetime**. So a diff registered by an earlier changed run keeps resolving to that path forever; skipping re-registration would leave the earlier run's bytes servable to anyone still holding the id. Removing the file makes that id 404 instead.

The shipped invariant: **after a comparison, `diff.png` exists exactly when that comparison produced one.**

To be precise about the two guarantees, since they differ in strength:

- **A passing result never exposes or registers a diff — absolute.** `result.artifacts` omits the diff key whenever the comparison produced none, and `register(diffPath)` is not called. This holds unconditionally, independent of the filesystem.
- **The stale bytes become unreachable — best effort.** Removal is what 404s an id issued by an earlier changed run. If the unlink fails (locked file, read-only mount), that older id stays servable until a later run succeeds in removing it.

Removal is best effort by design (see review findings below): because the first guarantee never depended on it, an undeletable file must not downgrade a genuinely passing comparison to a `capture-error`. The failure mode is also exactly the pre-change status quo, where `diff.png` was written on every comparison with a baseline and so always persisted.

Writing a diff stays load-bearing and still fails loudly, because a changed result registers that path and must not advertise a missing or stale image.

## Files intentionally excluded

- `src/manager/PanelView.tsx` — **not modified.** Verified it already handles this correctly: `availableImages` filters on artifact presence, the Diff tab is `disabled={!artifacts?.diff}`, and the `requestedImage` fallback (`availableImages.at(-1)`) resolves to Latest when a rerun of the same story drops the diff. No stale-selection bug, so no change was warranted.
- `src/node/approval.ts` — `approveCandidate` does not delete `diff.png`, so an approved story keeps its stale diff on disk until its next run. The clean fix needs `CompletedVisualResult` to carry `diffPath`, which is outside this task's scope. Note this is **not a regression**: pre-change, `diff.png` was written on every comparison with a baseline, so it always survived approval. The next run of that story now cleans it up.
- `preset.ts`, `server.test.ts`, README, configuration/capture docs, `package.json` — Agent B / Task 4.

## TDD red/green evidence

**Red** (`pnpm --filter @workspace/storybook-addon-visual-tests test compare runner`) — 7 failures, for the right reasons:

```
× passes identical pixels with compatible metadata
× treats host platform as provenance for a shared environment key
× requires review for malformed metadata even when pixels match
× requires review for baseline hash mismatch even when pixels match
× requires review for environment mismatch even when pixels match
× requires review when candidate metadata does not describe candidate bytes
× registers a diff for changed pixels, then deletes it when a later run passes
Tests  7 failed | 14 passed (21)
```

- compare: `AssertionError: expected Buffer[ 137, 80, 78, 71, ... ] to be undefined` — the diff was being serialized for zero-pixel comparisons.
- runner: `promise resolved "Buffer[ 100, 105, 102, 102, 45 ... ]" instead of rejecting` — the stale `diff.png` survived a later passing run.

**Green:** 76 tests pass.

I also verified every new **end-to-end** test is non-vacuous by restoring `master`'s `runner.ts`/`compare.ts` and re-running: each fails against the pre-change implementation.

```
× leaves no diff on disk or in the result for a real passing comparison
× leaves no diff on disk or in the result for a real metadata-only incompatibility
× kills an earlier run's diff id against the real artifact registry
× keeps a passing result when the stale diff cannot be removed
```

## Self-review outcome

Verified against the full diff: passing results neither expose nor register a diff; changed pixels still produce an inspectable one; metadata-only changes keep message + both images + approval; the sticky-registry leak is closed by deletion; approval and path-safety invariants untouched (`diffPath` comes from the same guarded `resolveArtifactPaths` as baseline/candidate); no unrelated file staged.

One edge case I probed empirically: `padImage` zero-fills, so a candidate larger than its baseline whose extra region is fully transparent yields `diffPixels: 0` → `changed` ("Image dimensions changed") with no diff. Correct — that diff would have been entirely transparent, and the message plus both images carry the signal.

## Subagent review findings and resolutions

Three reviewers were dispatched across two rounds. Round one returned **BLOCK** on one genuine finding; round two (scoped to the fix itself) returned **PROCEED** with follow-ups. Note one reviewer never produced output, so treat this as two independent reviews plus my own passes, not three:

1. **[Important — fixed]** `rm(diffPath, { force: true })` only suppresses `ENOENT`. On `EPERM`/`EACCES`/`EBUSY`/`EISDIR` it threw out of `finishCapture` into `runStory`'s catch, which rewrote an already-correct passing result as `capture-error` — and because that happened before `result.artifacts` was assigned, the user also lost the baseline and candidate images. I confirmed the user-visible impact: `TestProviderRow.tsx:27` counts `capture-error` as failed, so a cleanup unlink failure would report a passing story as a **failed visual test**. Reproduced with a failing test (a directory at `diff.png` makes non-recursive removal fail with something other than ENOENT), then made the removal best effort.

2. **[Pushed back]** The reviewer also suggested applying the same `.catch()` to the diff **write** branch "for symmetry". I disagree and did not: the operations have opposite consequences. A changed result *registers* `diffPath`, so silently swallowing a failed write would advertise a Diff tab pointing at a missing or stale file. Failing loudly there is correct.

3. **[Already addressed]** The reviewer flagged that every runner test mocked `comparePngs`, making the metadata-only test vacuous. I had reached the same conclusion independently and had already added two end-to-end tests running the **real** comparator through the runner with real PNG bytes and real baseline metadata, each pre-seeded with a stale `diff.png`.

4. **[Acknowledged, non-blocking]** The `padImage` transparent-padding edge case above — reviewer agreed it is narrow and not a regression.

Reviewers confirmed clean: ordering/state consistency (`result` is fresh per run; `completed` is written strictly after the fs op), concurrency (story ids are unique per selection; artifact dirs are keyed by story id), and type safety (`ComparisonResult.diff` was already optional; every consumer already guarded it).

## Checks run

| Check | Result |
| --- | --- |
| `pnpm --filter @workspace/storybook-addon-visual-tests test` | ✅ 76 passed (10 files) |
| `pnpm --filter @workspace/storybook-addon-visual-tests typecheck` | ✅ |
| `pnpm --filter @workspace/storybook-addon-visual-tests lint` | ✅ |
| `pnpm format:check` | ✅ |
| `git diff --check` | ✅ |
| `pnpm --filter @workspace/storybook-addon-visual-tests test:visual` | ✅ 1 passed (2.5m) — unblocked by #248 |

`test:visual` previously failed on `master` too, because the addon declared `playwright@1.55.1` alongside `@playwright/test@1.53.2` and Playwright collected no tests. #248 routed both through the catalog and it now passes.

## Storybook verification

Rebased onto `master` after #248 aligned the playwright versions through the catalog. **That unblocked both checks this PR previously could not run.**

The story tests now execute locally, and every panel story passes:

```
$ pnpm exec vitest run --project storybook Panel.stories
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

That covers the `Passed` assertions and the new `MetadataOnlyChange` story, so the play functions are verified rather than merely inferred.

I had also verified these states by querying the rendered DOM in a real browser before the tests could run; both agree.

Instead I verified the affected panel states in a **real browser** against the running Storybook, querying the rendered DOM directly for the same attributes the play functions assert on (`disabled`, `aria-pressed`, rendered `img` alt). This exercises the real component, but it is *not* the same as running the play functions — the `getByRole` queries and matchers themselves are unexecuted. All three states match the assertions exactly:

| Story | Result |
| --- | --- |
| `Passed` | Diff tab `disabled`, Latest `aria-pressed=true`, renders `candidate` |
| `ReviewChanges` | Diff tab enabled + `aria-pressed=true`, renders `diff`, Accept present |
| `MetadataOnlyChange` | "Changed" + message shown, Diff `disabled`, Latest active, Accept **enabled** |

Preview URLs:

- http://localhost:6006/?path=/story/visual-tests-panel--passed
- http://localhost:6006/?path=/story/visual-tests-panel--metadata-only-change
- http://localhost:6006/?path=/story/visual-tests-panel--review-changes
- http://localhost:6006/?path=/story/visual-tests-panel--baseline-only

Two story changes, both driven by this task's contract: assertions added to the existing `Passed` story (which had no guard that a passing result hides the Diff tab), and a new `MetadataOnlyChange` story covering a panel state this change newly creates — `changed` with **no** diff, which previously could not occur.

### Round two — review of the fix itself

5. **[Fixed]** No test used the real `ArtifactRegistry`, so the very behaviour justifying removal over non-registration — one immortal id per path — was assumed rather than tested. Added a test running a changed run then a passing one against the real registry: the id still resolves to the same path afterwards, and only deleting the bytes retires it.

6. **[Documented]** The blanket `.catch()` is silent and the addon has no logging surface, so a persistent failure would leak a stale diff with no signal. Recorded in-code as a known tradeoff to revisit if logging is ever added.

7. **[Deferred, with reasons]** A diff **write** failure on a *changed* story throws before `result.artifacts` is assigned, so baseline and candidate are lost too — the same collateral damage, on the case where those images matter most. Confirmed **entirely pre-existing**: on `master`, `writeFile` always ran for changed results and failed identically. Fixing it means deciding what that failure should do (likely degrade to `changed` without a diff) on a path Task 3 does not touch, and it interacts with the `completed` approval store. Better as its own change.
