### PR TITLE
chore(deps): align playwright versions through the catalog

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -35,6 +35,7 @@
     "@types/react-dom": "catalog:",
     "@typescript/native-preview": "catalog:",
     "@vitest/browser-playwright": "^4.1.10",
+    "playwright": "catalog:",
     "@workspace/config-typescript": "workspace:*",
     "motion": "^12.23.0",
     "next-themes": "catalog:",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "db:provision-rls": "docker compose exec -T -e PGPASSWORD=postgres postgres psql -U postgres -d llame -v ON_ERROR_STOP=1 < docker/postgres/rls-function-owner.sql"
   },
   "devDependencies": {
-    "@playwright/test": "1.53.2",
+    "@playwright/test": "catalog:",
     "@workspace/config-typescript": "workspace:*",
     "lefthook": "2.1.9",
     "prettier": "catalog:",

--- a/packages/storybook-addon-visual-tests/package.json
+++ b/packages/storybook-addon-visual-tests/package.json
@@ -18,11 +18,11 @@
   "dependencies": {
     "@storybook/icons": "2.1.0",
     "pixelmatch": "^7.1.0",
-    "playwright": "1.55.1",
+    "playwright": "catalog:",
     "pngjs": "^7.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "1.53.2",
+    "@playwright/test": "catalog:",
     "@storybook/nextjs-vite": "catalog:",
     "@storybook/react-vite": "^10.5.0",
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@hookform/resolvers':
       specifier: ^5.1.1
       version: 5.1.1
+    '@playwright/test':
+      specifier: 1.55.1
+      version: 1.55.1
     '@storybook/nextjs-vite':
       specifier: ^10.5.0
       version: 10.5.0
@@ -45,6 +48,9 @@ catalogs:
     oxlint:
       specifier: ^1.72.0
       version: 1.72.0
+    playwright:
+      specifier: 1.55.1
+      version: 1.55.1
     prettier:
       specifier: ^3.5.1
       version: 3.5.1
@@ -84,8 +90,8 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: 1.53.2
-        version: 1.53.2
+        specifier: 'catalog:'
+        version: 1.55.1
       '@workspace/config-typescript':
         specifier: workspace:*
         version: link:packages/config-typescript
@@ -272,7 +278,7 @@ importers:
         version: link:../../packages/ui
       next:
         specifier: 'catalog:'
-        version: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -303,7 +309,7 @@ importers:
         version: 10.5.0(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@4.1.10))(@vitest/runner@4.1.10)(react@19.2.7)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(vitest@4.1.10)
       '@storybook/nextjs-vite':
         specifier: 'catalog:'
-        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
+        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.81.5(react@19.2.7)
@@ -334,6 +340,9 @@ importers:
       oxlint:
         specifier: 'catalog:'
         version: 1.72.0(oxlint-tsgolint@0.24.0)
+      playwright:
+        specifier: 'catalog:'
+        version: 1.55.1
       react-hook-form:
         specifier: 'catalog:'
         version: 7.59.0(react@19.2.7)
@@ -372,7 +381,7 @@ importers:
         version: 5.1.1(react-hook-form@7.59.0(react@19.2.7))
       '@sentry/nextjs':
         specifier: ^10.63.0
-        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.100.2(esbuild@0.25.12))
+        version: 10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.100.2(esbuild@0.25.12))
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.81.5(react@19.2.7)
@@ -405,7 +414,7 @@ importers:
         version: 1.22.0(react@19.2.7)
       next:
         specifier: 'catalog:'
-        version: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -430,7 +439,7 @@ importers:
     devDependencies:
       '@storybook/nextjs-vite':
         specifier: 'catalog:'
-        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
+        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -485,18 +494,18 @@ importers:
         specifier: ^7.1.0
         version: 7.2.0
       playwright:
-        specifier: 1.55.1
+        specifier: 'catalog:'
         version: 1.55.1
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
     devDependencies:
       '@playwright/test':
-        specifier: 1.53.2
-        version: 1.53.2
+        specifier: 'catalog:'
+        version: 1.55.1
       '@storybook/nextjs-vite':
         specifier: 'catalog:'
-        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
+        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
       '@storybook/react-vite':
         specifier: ^10.5.0
         version: 10.5.0(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
@@ -620,7 +629,7 @@ importers:
     devDependencies:
       '@storybook/nextjs-vite':
         specifier: 'catalog:'
-        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
+        version: 10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
       '@tailwindcss/postcss':
         specifier: ^4.1.0
         version: 4.3.2
@@ -2773,8 +2782,8 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@playwright/test@1.53.2':
-    resolution: {integrity: sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==}
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7306,18 +7315,8 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-core@1.53.2:
-    resolution: {integrity: sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.55.1:
     resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.53.2:
-    resolution: {integrity: sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10604,9 +10603,9 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@playwright/test@1.53.2':
+  '@playwright/test@1.55.1':
     dependencies:
-      playwright: 1.53.2
+      playwright: 1.55.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -10952,7 +10951,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.63.0
 
-  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.100.2(esbuild@0.25.12))':
+  '@sentry/nextjs@10.63.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.100.2(esbuild@0.25.12))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -10965,7 +10964,7 @@ snapshots:
       '@sentry/react': 10.63.0(react@19.2.7)
       '@sentry/vercel-edge': 10.63.0
       '@sentry/webpack-plugin': 5.3.0(webpack@5.100.2(esbuild@0.25.12))
-      next: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -11195,18 +11194,18 @@ snapshots:
       - '@tmcp/auth'
       - typescript
 
-  '@storybook/nextjs-vite@10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))':
+  '@storybook/nextjs-vite@10.5.0(@babel/core@7.28.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))':
     dependencies:
       '@storybook/builder-vite': 10.5.0(esbuild@0.25.12)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
       '@storybook/react': 10.5.0(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)
       '@storybook/react-vite': 10.5.0(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(esbuild@0.25.12)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rollup@4.62.2)(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(webpack@5.100.2(esbuild@0.25.12))
-      next: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       storybook: 10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.7)
       vite: 6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
     optionalDependencies:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
@@ -15222,7 +15221,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -15242,7 +15241,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.10
       '@next/swc-win32-x64-msvc': 16.2.10
       '@opentelemetry/api': 1.9.1
-      '@playwright/test': 1.53.2
+      '@playwright/test': 1.55.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -15634,15 +15633,7 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-core@1.53.2: {}
-
   playwright-core@1.55.1: {}
-
-  playwright@1.53.2:
-    dependencies:
-      playwright-core: 1.53.2
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.55.1:
     dependencies:
@@ -16938,13 +16929,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7))(typescript@5.7.3)(vite@6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.53.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.28.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.5.0(@types/react@19.0.10)(prettier@3.5.1)(react@19.2.7)
       ts-dedent: 2.3.0
       vite: 6.4.3(@types/node@22.16.5)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,14 @@ minimumReleaseAgeExclude:
 # "catalog:" in package.json. Single edit point, no cross-package drift.
 catalog:
   "@hookform/resolvers": ^5.1.1
+  # `@playwright/test` and `playwright` are separate packages that MUST move
+  # together: they share a `playwright-core`, and `playwright install` only
+  # fetches the browser build its own version pins. A split (root on one
+  # version, the visual-test addon on another) leaves the browser the other
+  # half needs uninstalled — Storybook's browser-mode suite then launches
+  # nothing and reports zero tests. Bump both entries in the same change.
+  "@playwright/test": 1.55.1
+  playwright: 1.55.1
   # Node floor is 22.12 (engines/.node-version) — types match the runtime.
   "@types/node": ^22
   "@types/react": ^19


### PR DESCRIPTION
Unifies every Playwright declaration on `1.55.1` through the pnpm catalog. This
closes a still-open high-severity advisory and unbreaks the `Storybook component
tests` CI job, which has been running **zero tests** since #236 merged.

## What went wrong

Dependabot #236 fixed [GHSA-7mvr-c777-76hp](https://github.com/advisories/GHSA-7mvr-c777-76hp)
(high, `playwright < 1.55.1`). Its own title says it bumped "2 directories", but
it changed only one file — because the root declares **`@playwright/test`** while
the addon declares **`playwright`**. Those are different package names, so the
root was left on `1.53.2`.

Two consequences, both live on `master` today:

**1. The Storybook browser suite cannot start.** CI runs
`pnpm exec playwright install --with-deps chromium` at the root, which resolved
`@playwright/test@1.53.2` and installed `chromium_headless_shell-1179`. But
`@vitest/browser-playwright` declares `peerDependencies: { playwright: "*" }`,
and the only `playwright` in the tree was the addon's `1.55.1`, which needs
`chromium_headless_shell-1193`. The resolution is visible in the pnpm path
itself: `@vitest+browser-playwright@4.1.10_playwright@1.55.1_…`. Result:

```
Error: browserType.launch: Executable doesn't exist at
  /home/runner/.cache/ms-playwright/chromium_headless_shell-1193/chrome-linux/headless_shell
 Test Files  (50)
      Tests  no tests
```

The job reported failure without executing a single test, so nothing in
`packages/ui` or `apps/web` has actually been browser-tested since #236.

**2. The advisory is still open.** The alert on
`packages/storybook-addon-visual-tests/package.json` shows `fixed`, but the alert
on `pnpm-lock.yaml` is still **open**, because root's `@playwright/test@1.53.2`
kept pulling `playwright-core@1.53.2` into the tree. Verified after this change:
`rg -c "playwright(-core)?@1\.53\.2" pnpm-lock.yaml` → no matches.

## The fix

Both package names now resolve through one catalog entry pair, so they can only
move together:

```yaml
"@playwright/test": 1.55.1
playwright: 1.55.1
```

- root `@playwright/test`: `1.53.2` → `catalog:`
- addon `playwright` and `@playwright/test` → `catalog:`
- `apps/storybook` gains an explicit `playwright: catalog:` devDependency

That last one is deliberate. `apps/storybook` never declared Playwright at all —
it inherited a version through `@vitest/browser-playwright`'s `"*"` peer, which
happened to resolve to a *sibling package's* dependency. That invisible coupling
is what made a single-package Dependabot bump silently break a different
workspace. Declaring it makes the dependency real and puts it under the catalog.

The catalog carries a comment explaining that the two entries must be bumped
together and what breaks when they aren't.

**Why the catalog is safe here:** Dependabot does update pnpm catalog entries —
commit `a7a2d5c0` bumps `next` directly in `pnpm-workspace.yaml`. So this does
not park these deps outside Dependabot's reach.

## Why 1.55.1 and not 1.62.0

Open Dependabot PR #242 proposes `playwright@1.62.0`. That version was published
`2026-07-24T21:56Z` — roughly **25 hours** before this PR. `pnpm-workspace.yaml`
sets `minimumReleaseAge: 10080` (7 days) precisely to refuse resolving releases
that young, so 1.62.0 cannot be resolved here for ~6 more days. Aligning on
1.55.1 keeps the security fix while respecting the repo's own supply-chain
cooldown. #242 should be re-evaluated after the cooldown, and whoever takes it
must bump **both** catalog entries.

## Known follow-up: the 197 baselines need re-approval

Not in this PR, and it is not a regression this PR introduces — it is a latent
consequence of #236 that this PR makes visible.

All 197 committed baselines are stamped `playwrightVersion: 1.53.2`, Chromium
`138.0.7204.23`. The addon has been capturing with `1.55.1` / Chromium `140`
since #236, and `compatibleMetadata` compares browser version and Playwright
version exactly, so a visual run reports every story incompatible. This has been
true on `master` since #236 and is invisible to CI, because the addon's smoke
fixture generates its own baselines rather than using the committed ones.

Re-approving all 197 is a separate, reviewable change (197 binary PNGs), kept out
of this PR so the dependency change stays readable.

## Checks run

```
pnpm install                                          # clean, no 1.53.2 remains
pnpm exec playwright --version                        # 1.55.1 (was 1.53.2)
pnpm exec playwright install chromium                 # fetches shell 1193
pnpm exec turbo run test:storybook --filter=storybook # 251/253 passed, see below
```

**The suite executes again.** Before this change it reported `Test Files (50) /
Tests no tests`; it now runs **253 tests, 251 passing**.

The 2 failures are load-induced flakes, not regressions. Both are the same
shape — a `waitFor(() => expect(…).not.toBeInTheDocument())` after a close
click, where the Base UI overlay is still mid-exit-animation (`data-closed`,
`data-ending-style` present) when the 1s default timeout expires:
`alert-dialog.stories.tsx > Media` and `popover.stories.tsx > Alignments`. Re-run
in isolation they pass 11/11, so they are contention-sensitive rather than
broken, and neither is touched by this PR. Worth watching on CI, and worth
hardening separately if they recur.

Note there is no "before" run to diff against: `master` cannot execute this
suite at all, which is the bug being fixed.

Resolution verified at all three consumers, each now `1.55.1`:

| Consumer | Resolves | Needs |
| --- | --- | --- |
| root CLI (`playwright install`) | 1.55.1 | installs shell 1193 |
| `apps/storybook` (vitest browser) | 1.55.1 | shell 1193 ✅ |
| addon capture engine | 1.55.1 | shell 1193 ✅ |

Note the separate `browser e2e (Playwright, worker mode)` failure is **not**
addressed here and is not caused by this skew — it is 7 genuine test failures
(locator timeouts, `Cannot read properties of undefined (reading 'state')`) that
also fail on `master`. It needs its own investigation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Playwright to `1.55.1` across the monorepo via the `pnpm` catalog to close the open advisory and restore the Storybook component tests in CI.

- **Bug Fixes**
  - Fixed CI where the Storybook browser suite ran zero tests due to `@playwright/test` vs `playwright` version skew; the suite now executes again (253 tests run, 251 pass).

- **Dependencies**
  - Route both `@playwright/test` and `playwright` through the catalog at `1.55.1` so they move together.
  - Add an explicit `playwright: catalog:` devDependency in `apps/storybook` to avoid peer-resolution drift.
  - Stay on `1.55.1` (not `1.62.0`) to respect the repo’s `minimumReleaseAge: 10080`.

<sup>Written for commit 36d8317a057b9300d321d77bb6301dd545cc7014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

