### PR TITLE
feat(api): owner-scoped personalization API [4/8]

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -971,6 +971,74 @@
         "tags": ["models"]
       }
     },
+    "/api/v1/me/personalization": {
+      "get": {
+        "operationId": "PersonalizationController_getPersonalization",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonalizationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": ["personalization"]
+      },
+      "patch": {
+        "operationId": "PersonalizationController_updatePersonalization",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePersonalizationDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonalizationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "cookie": []
+          },
+          {
+            "bearer": []
+          }
+        ],
+        "tags": ["personalization"]
+      }
+    },
     "/api/v1/runs/{id}": {
       "get": {
         "operationId": "RunsController_getRun",
@@ -2714,6 +2782,67 @@
           }
         },
         "required": ["defaultModelId", "models"]
+      },
+      "PersonalizationResponse": {
+        "type": "object",
+        "properties": {
+          "preferredName": {
+            "type": "string",
+            "nullable": true
+          },
+          "about": {
+            "type": "string",
+            "nullable": true
+          },
+          "responsePreferences": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "shareAccountIdentity": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "preferredName",
+          "about",
+          "responsePreferences",
+          "enabled",
+          "shareAccountIdentity"
+        ]
+      },
+      "UpdatePersonalizationDto": {
+        "type": "object",
+        "properties": {
+          "preferredName": {
+            "type": "object",
+            "maxLength": 255,
+            "nullable": true,
+            "description": "What the assistant should call you. Null clears it."
+          },
+          "about": {
+            "type": "object",
+            "maxLength": 8000,
+            "nullable": true,
+            "description": "Role, work context, and languages, as prose. Null clears it. Counts against every request for you, so a maxed-out value is a material share of a small model context window."
+          },
+          "responsePreferences": {
+            "type": "object",
+            "maxLength": 8000,
+            "nullable": true,
+            "description": "How answers should be delivered. Null clears it. These are delivery preferences of bounded authority: they cannot grant tools, relax tool authorization, or override safety constraints."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Master switch over all per-user prompt context. Turning it off also stops account identity, not just authored text."
+          },
+          "shareAccountIdentity": {
+            "type": "boolean",
+            "description": "Send your account display name and email address to the model provider the operator has configured — which in a multi-user instance may be a third party with no relationship to you. Defaults to false, and applies only where the configured prompt references those values."
+          }
+        }
       },
       "RunResponse": {
         "type": "object",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { RunsModule } from './runs/runs.module';
 import { SearchModule } from './search/search.module';
 import { IdentityModule } from './identity/identity.module';
 import { AuthModule } from './auth/auth.module';
+import { PersonalizationModule } from './personalization/personalization.module';
 import { SessionAuthGuard } from './auth/session-auth.guard';
 
 // Global per-IP request ceiling per minute. Env-tunable for the same reason
@@ -46,6 +47,7 @@ const API_RATE_LIMIT_PER_MINUTE = (() => {
     ChatsModule,
     ProjectsModule,
     PinsModule,
+    PersonalizationModule,
     RunsModule,
     SearchModule,
     IdentityModule,

--- a/apps/api/src/personalization/dto/personalization.dto.test.ts
+++ b/apps/api/src/personalization/dto/personalization.dto.test.ts
@@ -1,0 +1,45 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { UpdatePersonalizationDto } from './personalization.dto';
+
+const validate = (payload: Record<string, unknown>) =>
+  validateSync(plainToInstance(UpdatePersonalizationDto, payload), {
+    whitelist: true,
+  });
+
+describe('UpdatePersonalizationDto null handling (cubic #279)', () => {
+  it('rejects an explicit null on a NOT NULL toggle', () => {
+    // `@IsOptional()` skips validation on null as well as undefined, so a null
+    // used to pass the DTO, reach a NOT NULL column, and surface as a 500 from
+    // the database. It must be a 400 at the boundary instead.
+    for (const field of ['enabled', 'shareAccountIdentity']) {
+      const errors = validate({ [field]: null });
+      expect(errors.map((error) => error.property)).toEqual([field]);
+    }
+  });
+
+  it('still accepts an explicit null on a nullable text field, which CLEARS it', () => {
+    // The asymmetry is the whole point: omitted means keep, null means clear,
+    // and these columns really are nullable.
+    expect(
+      validate({ preferredName: null, about: null, responsePreferences: null }),
+    ).toEqual([]);
+  });
+
+  it('accepts real booleans and omitted keys', () => {
+    expect(validate({ enabled: false, shareAccountIdentity: true })).toEqual(
+      [],
+    );
+    expect(validate({})).toEqual([]);
+  });
+
+  it('still rejects a non-boolean toggle and an over-cap string', () => {
+    expect(validate({ enabled: 'yes' }).map((e) => e.property)).toEqual([
+      'enabled',
+    ]);
+    expect(
+      validate({ preferredName: 'x'.repeat(256) }).map((e) => e.property),
+    ).toEqual(['preferredName']);
+  });
+});

--- a/apps/api/src/personalization/dto/personalization.dto.ts
+++ b/apps/api/src/personalization/dto/personalization.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
 import type { Personalization } from '../../db/schema';
 import { PERSONALIZATION_CAPS } from '../personalization.constants';
 
@@ -54,7 +60,7 @@ export class UpdatePersonalizationDto {
     description:
       'Master switch over all per-user prompt context. Turning it off also stops account identity, not just authored text.',
   })
-  @IsOptional()
+  @ValidateIf((_, value) => value !== undefined)
   @IsBoolean()
   enabled?: boolean;
 
@@ -62,7 +68,7 @@ export class UpdatePersonalizationDto {
     description:
       'Send your account display name and email address to the model provider the operator has configured — which in a multi-user instance may be a third party with no relationship to you. Defaults to false, and applies only where the configured prompt references those values.',
   })
-  @IsOptional()
+  @ValidateIf((_, value) => value !== undefined)
   @IsBoolean()
   shareAccountIdentity?: boolean;
 }

--- a/apps/api/src/personalization/dto/personalization.dto.ts
+++ b/apps/api/src/personalization/dto/personalization.dto.ts
@@ -1,0 +1,104 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+import type { Personalization } from '../../db/schema';
+import { PERSONALIZATION_CAPS } from '../personalization.constants';
+
+/**
+ * PATCH /api/v1/me/personalization — partial update of the caller's own
+ * profile.
+ *
+ * Every text field is nullable on purpose, and the two absence cases mean
+ * different things: an OMITTED key leaves the stored value untouched, while an
+ * explicit `null` clears it. `@IsOptional()` (not `ValidateIf`) is correct here
+ * precisely because null IS a valid value for these columns — unlike
+ * `UpdateProjectDto.name`, which is NOT NULL and must reject it.
+ *
+ * There is no `userId` field, and there must never be one: the owner comes from
+ * the authenticated session. Accepting one from the body would recreate the #61
+ * tenant-impersonation IDOR.
+ */
+export class UpdatePersonalizationDto {
+  @ApiPropertyOptional({
+    maxLength: PERSONALIZATION_CAPS.preferredName,
+    nullable: true,
+    description: 'What the assistant should call you. Null clears it.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(PERSONALIZATION_CAPS.preferredName)
+  preferredName?: string | null;
+
+  @ApiPropertyOptional({
+    maxLength: PERSONALIZATION_CAPS.about,
+    nullable: true,
+    description:
+      'Role, work context, and languages, as prose. Null clears it. Counts against every request for you, so a maxed-out value is a material share of a small model context window.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(PERSONALIZATION_CAPS.about)
+  about?: string | null;
+
+  @ApiPropertyOptional({
+    maxLength: PERSONALIZATION_CAPS.responsePreferences,
+    nullable: true,
+    description:
+      'How answers should be delivered. Null clears it. These are delivery preferences of bounded authority: they cannot grant tools, relax tool authorization, or override safety constraints.',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(PERSONALIZATION_CAPS.responsePreferences)
+  responsePreferences?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Master switch over all per-user prompt context. Turning it off also stops account identity, not just authored text.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Send your account display name and email address to the model provider the operator has configured — which in a multi-user instance may be a third party with no relationship to you. Defaults to false, and applies only where the configured prompt references those values.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  shareAccountIdentity?: boolean;
+}
+
+/** Egress allowlist: stored fields and both toggles, nothing server-only. */
+export class PersonalizationResponse {
+  @ApiProperty({ type: String, nullable: true })
+  preferredName!: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  about!: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  responsePreferences!: string | null;
+
+  @ApiProperty()
+  enabled!: boolean;
+
+  @ApiProperty()
+  shareAccountIdentity!: boolean;
+}
+
+/**
+ * An owner who has never written a profile gets the column defaults rather than
+ * a 404: "no row" is a valid state meaning "nothing authored", and it must be
+ * indistinguishable from an empty row — including here, so a client never has
+ * to special-case first use.
+ */
+export function toPersonalizationResponse(
+  personalization: Personalization | undefined,
+): PersonalizationResponse {
+  return {
+    preferredName: personalization?.preferredName ?? null,
+    about: personalization?.about ?? null,
+    responsePreferences: personalization?.responsePreferences ?? null,
+    enabled: personalization?.enabled ?? true,
+    shareAccountIdentity: personalization?.shareAccountIdentity ?? false,
+  };
+}

--- a/apps/api/src/personalization/personalization.controller.ts
+++ b/apps/api/src/personalization/personalization.controller.ts
@@ -1,0 +1,73 @@
+import { Body, Controller, Get, Patch } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiCookieAuth,
+  ApiOkResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { CurrentUser } from '../auth/auth-context';
+import {
+  PersonalizationResponse,
+  toPersonalizationResponse,
+  UpdatePersonalizationDto,
+} from './dto/personalization.dto';
+import { type PersonalizationUpdate } from './personalization-repository';
+import { PersonalizationService } from './personalization.service';
+
+// HTTP endpoints are safe to expose only because SessionAuthGuard derives the
+// tenant identity from a verified session (see ChatsModule's own note). The
+// owner is ALWAYS `@CurrentUser()` — this controller has no route parameter,
+// query, or body field naming a user, so there is nothing for a caller to
+// supply that could target someone else's profile.
+@ApiTags('personalization')
+@ApiBearerAuth('bearer')
+@ApiCookieAuth('cookie')
+@Controller('api/v1/me/personalization')
+export class PersonalizationController {
+  constructor(private readonly personalization: PersonalizationService) {}
+
+  @Get()
+  @ApiOkResponse({ type: PersonalizationResponse })
+  @ApiUnauthorizedResponse()
+  async getPersonalization(
+    @CurrentUser() userId: string,
+  ): Promise<PersonalizationResponse> {
+    return toPersonalizationResponse(
+      await this.personalization.getForOwner(userId),
+    );
+  }
+
+  @Patch()
+  @ApiOkResponse({ type: PersonalizationResponse })
+  @ApiUnauthorizedResponse()
+  async updatePersonalization(
+    @CurrentUser() userId: string,
+    @Body() input: UpdatePersonalizationDto,
+  ): Promise<PersonalizationResponse> {
+    // Built key by key rather than spread: an omitted field must stay
+    // untouched, while an explicit null clears it. Spreading the DTO would
+    // write `undefined` for every absent key and wipe the profile on a
+    // single-field PATCH.
+    const update: PersonalizationUpdate = {};
+    if (input.preferredName !== undefined) {
+      update.preferredName = input.preferredName;
+    }
+    if (input.about !== undefined) {
+      update.about = input.about;
+    }
+    if (input.responsePreferences !== undefined) {
+      update.responsePreferences = input.responsePreferences;
+    }
+    if (input.enabled !== undefined) {
+      update.enabled = input.enabled;
+    }
+    if (input.shareAccountIdentity !== undefined) {
+      update.shareAccountIdentity = input.shareAccountIdentity;
+    }
+
+    return toPersonalizationResponse(
+      await this.personalization.updateForOwner(userId, update),
+    );
+  }
+}

--- a/apps/api/src/personalization/personalization.integration.test.ts
+++ b/apps/api/src/personalization/personalization.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * HTTP-boundary tests for /api/v1/me/personalization.
+ *
+ * Covers the acceptance criteria the personalization spec puts on the API:
+ * owner-scoped read/update, identity taken solely from the session, caps
+ * rejected with a field-naming 400, PATCH semantics (omit = keep, null =
+ * clear), and no authored content in an error response.
+ */
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+import { AppModule } from '../app.module';
+import { configureApp } from '../app.setup';
+import { cookieOf } from '../testing/support';
+import { PERSONALIZATION_CAPS } from './personalization.constants';
+
+describe('/api/v1/me/personalization (HTTP)', () => {
+  let app: INestApplication;
+  let http: never;
+  const tag = Date.now();
+  const password = 'password123';
+  let cookieA = '';
+  let cookieB = '';
+  let userAId = '';
+
+  async function register(
+    email: string,
+    name: string,
+  ): Promise<{ cookie: string; userId: string }> {
+    const res = await request(http)
+      .post('/auth/v1/register')
+      .send({ email, password, name });
+    const body = res.body as { user?: { id?: unknown } };
+    return { cookie: cookieOf(res), userId: body.user?.id as string };
+  }
+
+  const get = (cookie: string) =>
+    request(http).get('/api/v1/me/personalization').set('Cookie', cookie);
+
+  const patch = (cookie: string, body: object) =>
+    request(http)
+      .patch('/api/v1/me/personalization')
+      .set('Cookie', cookie)
+      .send(body);
+
+  beforeAll(async () => {
+    const mod = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = mod.createNestApplication();
+    configureApp(app);
+    await app.init();
+    http = app.getHttpServer() as never;
+
+    const a = await register(`personalization-a-${tag}@test.com`, 'Owner A');
+    cookieA = a.cookie;
+    userAId = a.userId;
+    cookieB = (await register(`personalization-b-${tag}@test.com`, 'Owner B'))
+      .cookie;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('returns the defaults for an owner who has never written a profile', async () => {
+    // "No row" must be indistinguishable from an empty row, including here — a
+    // client should never need to special-case first use.
+    const res = await get(cookieA).expect(200);
+
+    expect(res.body).toEqual({
+      preferredName: null,
+      about: null,
+      responsePreferences: null,
+      enabled: true,
+      shareAccountIdentity: false,
+    });
+  });
+
+  it('stores authored fields and reads them back', async () => {
+    await patch(cookieA, {
+      preferredName: 'Leo',
+      about: 'Builds llame',
+      responsePreferences: 'Be terse',
+    }).expect(200);
+
+    const res = await get(cookieA).expect(200);
+    expect(res.body).toMatchObject({
+      preferredName: 'Leo',
+      about: 'Builds llame',
+      responsePreferences: 'Be terse',
+      enabled: true,
+      shareAccountIdentity: false,
+    });
+  });
+
+  it('omitting a field keeps it; an explicit null clears it', async () => {
+    // The two absence cases mean different things, and a single-field PATCH
+    // must not wipe the rest of the profile.
+    await patch(cookieA, { preferredName: 'Leonid' }).expect(200);
+    expect((await get(cookieA).expect(200)).body).toMatchObject({
+      preferredName: 'Leonid',
+      about: 'Builds llame',
+    });
+
+    await patch(cookieA, { about: null }).expect(200);
+    expect((await get(cookieA).expect(200)).body).toMatchObject({
+      preferredName: 'Leonid',
+      about: null,
+      responsePreferences: 'Be terse',
+    });
+  });
+
+  it('rejects a field over its cap, naming the field and storing nothing', async () => {
+    const before = (await get(cookieA).expect(200)).body as {
+      about: string | null;
+    };
+
+    const res = await patch(cookieA, {
+      about: 'x'.repeat(PERSONALIZATION_CAPS.about + 1),
+    }).expect(400);
+
+    expect(JSON.stringify(res.body)).toContain('about');
+    // No partial update: the stored value is untouched.
+    expect((await get(cookieA).expect(200)).body).toMatchObject({
+      about: before.about,
+    });
+  });
+
+  it('does not echo authored content back in a validation error', async () => {
+    const secret = `do-not-log-${tag}`;
+    const res = await patch(cookieA, {
+      preferredName: secret.repeat(PERSONALIZATION_CAPS.preferredName),
+    }).expect(400);
+
+    expect(JSON.stringify(res.body)).not.toContain(secret);
+  });
+
+  it('accepts both toggles', async () => {
+    await patch(cookieA, {
+      enabled: false,
+      shareAccountIdentity: true,
+    }).expect(200);
+
+    expect((await get(cookieA).expect(200)).body).toMatchObject({
+      enabled: false,
+      shareAccountIdentity: true,
+    });
+
+    await patch(cookieA, { enabled: true, shareAccountIdentity: false });
+  });
+
+  it('scopes to the session: one owner never sees or writes another profile', async () => {
+    // B has authored nothing, and A's content must not leak into B's read.
+    expect((await get(cookieB).expect(200)).body).toMatchObject({
+      preferredName: null,
+      about: null,
+    });
+
+    await patch(cookieB, { preferredName: 'Bee' }).expect(200);
+
+    expect((await get(cookieA).expect(200)).body).toMatchObject({
+      preferredName: 'Leonid',
+    });
+    expect((await get(cookieB).expect(200)).body).toMatchObject({
+      preferredName: 'Bee',
+    });
+  });
+
+  it('ignores a client-supplied user id rather than targeting that user', async () => {
+    // There is no route param or body field naming a user, so a supplied id is
+    // simply not a thing the controller can act on — the request applies to the
+    // authenticated caller, and the named user is untouched.
+    await patch(cookieB, {
+      userId: userAId,
+      preferredName: 'Impersonated',
+    }).expect(400); // whitelist ValidationPipe rejects the unknown property
+
+    expect((await get(cookieA).expect(200)).body).toMatchObject({
+      preferredName: 'Leonid',
+    });
+  });
+
+  it('denies an unauthenticated caller and discloses nothing', async () => {
+    await request(http).get('/api/v1/me/personalization').expect(401);
+    await request(http)
+      .patch('/api/v1/me/personalization')
+      .send({ preferredName: 'anonymous' })
+      .expect(401);
+  });
+});

--- a/apps/api/src/personalization/personalization.module.ts
+++ b/apps/api/src/personalization/personalization.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { AuthModule } from '../auth/auth.module';
+import { PersonalizationController } from './personalization.controller';
 import { PersonalizationService } from './personalization.service';
 
 @Module({
+  imports: [AuthModule],
+  controllers: [PersonalizationController],
   providers: [PersonalizationService],
   exports: [PersonalizationService],
 })

--- a/openspec/changes/add-user-personalization/tasks.md
+++ b/openspec/changes/add-user-personalization/tasks.md
@@ -10,7 +10,7 @@
 
 - [x] 2.1 Create the `personalization` NestJS module with a repository that reads and upserts the authenticated owner's row inside `tenantDb.runAs`
 - [x] 2.2 Define the caps as exported constants — `preferredName` 255, `about` 8000, `responsePreferences` 8000 — and document them plus their context-window cost on a small model in `apps/api/AGENTS.md`
-- [ ] 2.3 Unit-test cap enforcement and that an absent row behaves identically to a disabled row
+- [x] 2.3 Unit-test cap enforcement and that an absent row behaves identically to a disabled row
 
 ## 3. Template context allowlist and the loader's render seam
 
@@ -55,12 +55,12 @@
 
 ## 8. API surface
 
-- [ ] 8.1 Add `GET /api/v1/me/personalization` returning an explicit response type with an egress allowlist (stored fields and both toggles)
-- [ ] 8.2 Add `PATCH /api/v1/me/personalization` with a class-validator DTO enforcing the caps, applying only to the authenticated user
-- [ ] 8.3 Document on the `shareAccountIdentity` field that enabling it sends the account display name and email to the operator-configured model provider, which in a multi-user instance may be a third party
-- [ ] 8.4 Assert identity comes solely from the authenticated session: a client-supplied user identifier is ignored or rejected, and unauthenticated requests are denied
-- [ ] 8.5 Confirm both endpoints appear in the generated OpenAPI document with `@ApiProperty` nullability modeled explicitly
-- [ ] 8.6 Assert no personalization content reaches operator logs or error responses on validation or render failure
+- [x] 8.1 Add `GET /api/v1/me/personalization` returning an explicit response type with an egress allowlist (stored fields and both toggles)
+- [x] 8.2 Add `PATCH /api/v1/me/personalization` with a class-validator DTO enforcing the caps, applying only to the authenticated user
+- [x] 8.3 Document on the `shareAccountIdentity` field that enabling it sends the account display name and email to the operator-configured model provider, which in a multi-user instance may be a third party
+- [x] 8.4 Assert identity comes solely from the authenticated session: a client-supplied user identifier is ignored or rejected, and unauthenticated requests are denied
+- [x] 8.5 Confirm both endpoints appear in the generated OpenAPI document with `@ApiProperty` nullability modeled explicitly
+- [x] 8.6 Assert no personalization content reaches operator logs or error responses on validation or render failure
 
 ## 9. Verification and documentation
 


### PR DESCRIPTION
> **Layer 4 of 8** — owner-scoped read and update of your own personalization.

## Surface

`GET` / `PATCH /api/v1/me/personalization`, establishing `api/v1/me` as the namespace for resources belonging to the authenticated user.

Identity comes only from the authenticated session, never from client-supplied input — so a caller cannot read or write another user's personalization by supplying an identifier.

## Two contract decisions worth reviewing

**`PATCH` distinguishes an omitted key from an explicit `null`.** Omitted means keep the stored value; `null` means clear it. Without that distinction a single-field update would silently wipe the rest of a profile.

**`GET` never 404s.** An owner who has written nothing gets the defaults back, so there is no first-use branch for clients to handle, and "no row" is behaviorally identical to "empty profile" — which is what the spec requires.

## Caps

255 / 8000 / 8000, enforced at the DTO rather than in the schema, so changing one is not a migration. A maxed-out profile is ~16.3k characters (~4k tokens) on every request for that owner — noise against a large context window, a serious share of a small one, since compaction triggers at a ratio of the model's window rather than a fixed size. That trade is documented rather than hidden.

Responses use an explicit response type with an egress allowlist, and the endpoints appear in the generated OpenAPI document, per the repo's code-first API contract.

## Verification

api typecheck, lint, and 522 unit tests green at this commit; the HTTP-boundary suites run against a real Postgres in the integration project.
