### PR TITLE
fix(web): guard undefined tool-part state to stop chat-run crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 _Reverse-chronological record of shipped work — features, fixes, and chores. Newest first._
 
+# 2026-08-06
+
+- Fixed browser crash during chat runs (#260): `TypeError: Cannot read properties of undefined (reading 'state')` fired when a tool part entered the `dynamic-tool` / `tool-*` render branch without a `state` field — the `as ToolUIPart` cast bypassed the type system but the runtime data from stream reconstruction or history replay could omit it. Guarded with a `?? "input-streaming"` fallback (the earliest lifecycle state) at the caller site, keeping the vendored `@ai-elements` component unmodified.
+
 # 2026-08-05
 
 - Fixed cross-file integration flake (#263): `app.integration.test.ts` booted the full AppModule (including pg-boss queue consumers) in a `beforeEach` with no teardown — the first file alphabetically, so its leaked workers survived into every subsequent file and errored when the pool closed. Added `afterAll → app.close()`, converted to `beforeAll`/`afterAll`, and added a process-level `uncaughtException`/`unhandledRejection` reporter to the integration setup so future leaked-handle errors name the active file instead of the victim.

--- a/apps/web/app/(chat)/components/chat-page.tsx
+++ b/apps/web/app/(chat)/components/chat-page.tsx
@@ -612,7 +612,7 @@ function ChatSessionContent({
                             <Tool key={messagePartKey}>
                               <ToolHeader
                                 type={toolPart.type}
-                                state={toolPart.state}
+                                state={toolPart.state ?? "input-streaming"}
                                 title={
                                   part.type === "dynamic-tool"
                                     ? toolPart.toolName


### PR DESCRIPTION
## Summary

- Guard `toolPart.state` with `?? "input-streaming"` in the tool-rendering branch of `chat-page.tsx`, fixing the `TypeError: Cannot read properties of undefined (reading 'state')` browser crash during tool-loop and refresh-mid-run scenarios
- The `as ToolUIPart` cast bypassed the type system, but runtime data from stream reconstruction or history replay could arrive without `state` populated
- Vendored `@ai-elements` component left unmodified — the fallback is at the caller site only

Closes #260

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a browser crash in chat runs by defaulting missing tool-part `state` to `input-streaming` in `chat-page.tsx`. Stops `TypeError: Cannot read properties of undefined (reading 'state')` during tool loops or mid-run refresh, keeps vendored `@ai-elements` unchanged, and closes #260.

<sup>Written for commit c9c6ed4cbb3c79500c601480dd4b709e3e45b7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a browser crash that could occur during chat runs when replayed or reconstructed tool data was missing a state.
  * Tool activity now displays safely with an appropriate fallback status when state information is unavailable.

* **Documentation**
  * Added a changelog entry documenting the chat stability fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->