### PR TITLE
refactor(web): replace `as ToolUIPart` cast with SDK type guard (#291)

### DIFF
--- a/apps/web/app/(chat)/components/chat-page.tsx
+++ b/apps/web/app/(chat)/components/chat-page.tsx
@@ -55,7 +55,12 @@ import {
   notificationLabel,
   streamingRunId,
 } from "@/lib/services/chat/run-notifications";
-import { DefaultChatTransport, type ToolUIPart, type UIMessage } from "ai";
+import {
+  DefaultChatTransport,
+  getToolName,
+  isToolUIPart,
+  type UIMessage,
+} from "ai";
 import { MessageUsage } from "./message-usage";
 import { parseCapNoticePart, ToolCapNoticePart } from "./tool-cap-notice-part";
 import { authAwareFetch } from "@/lib/api/client";
@@ -595,35 +600,24 @@ function ChatSessionContent({
                               {part.text}
                             </MessageResponse>
                           );
-                        } else if (
-                          part.type === "dynamic-tool" ||
-                          part.type.startsWith("tool-")
-                        ) {
-                          // Tool-calling loop (D5): render the agent's tool
-                          // use identically live or reloaded — persisted
-                          // history carries typed `tool-<name>` parts,
-                          // `dynamic-tool` is the live edge case; both share
-                          // the {state,input,output,errorText} shape AI
-                          // Elements' Tool consumes.
-                          const toolPart = part as ToolUIPart & {
-                            toolName?: string;
-                          };
+                        } else if (isToolUIPart(part)) {
+                          const toolName = getToolName(part);
                           return (
                             <Tool key={messagePartKey}>
                               <ToolHeader
-                                type={toolPart.type}
-                                state={toolPart.state ?? "input-streaming"}
+                                type={`tool-${toolName}`}
+                                state={part.state ?? "input-streaming"}
                                 title={
                                   part.type === "dynamic-tool"
-                                    ? toolPart.toolName
+                                    ? toolName
                                     : undefined
                                 }
                               />
                               <ToolContent>
-                                <ToolInput input={toolPart.input} />
+                                <ToolInput input={part.input} />
                                 <ToolOutput
-                                  output={toolPart.output}
-                                  errorText={toolPart.errorText}
+                                  output={part.output}
+                                  errorText={part.errorText}
                                 />
                               </ToolContent>
                             </Tool>


### PR DESCRIPTION
## Summary

- Replace the unsafe `as ToolUIPart & { toolName?: string }` cast with the AI SDK's exported `isToolUIPart()` type guard and `getToolName()` helper
- The cast bypassed TypeScript's narrowing — a tool part arriving from stream reconstruction without `state` populated compiled clean but crashed at runtime (#260)
- The `?? "input-streaming"` runtime fallback stays as defense against incomplete stream data that the type system can't see
- Net -6 lines: the manual `startsWith("tool-")` check, the `as` cast, and the intermediary `toolPart` variable are all gone

This is the first migration demonstrating the pattern proposed in #291: type guard functions over `as` casts in app code.

Depends on #290 (includes its fix commit).

Closes #291

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the unsafe cast in the chat tool-render path with the `ai` SDK’s `isToolUIPart()` and `getToolName()` to improve type safety and unify tool headers. Keeps a safe default for missing `state` to prevent the crash from #260. Closes #291.

- **Refactors**
  - Use `isToolUIPart()` for narrowing; remove `startsWith("tool-")`, the `as ToolUIPart` cast, and the temp variable.
  - Set header type to `tool-${getToolName(part)}` and title for `dynamic-tool`.
  - Keep `state ?? "input-streaming"` and render input, output, and error from the narrowed part.

<sup>Written for commit e33bf7c716bdb042d39010b2891bfa9a4d28ae2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/leon0399/llame/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a browser crash that could occur during chat runs when tool data was missing a status.
  - Improved tool-message rendering for both named and dynamically generated tools.
  - Added a safe fallback so in-progress tool activity displays correctly instead of producing an error.

- **Documentation**
  - Added a changelog entry documenting the chat-run crash fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->